### PR TITLE
fix(crowd.mtla.me): eliminate intermittent 404 on project navigation (#6)

### DIFF
--- a/apps/crowd.mtla.me/CLAUDE.md
+++ b/apps/crowd.mtla.me/CLAUDE.md
@@ -121,6 +121,7 @@ bun dev                        # Dev server
 bun run cli project <command>  # CLI
 bun run build                  # Production build
 bun run lint                   # Linter
+bunx tsc --noEmit              # Typecheck (no script alias exists)
 ```
 
 ## Testing
@@ -150,11 +151,14 @@ test("test", async () => {
 
 1. **ALWAYS use Effect-TS** - no async/await
 2. **Funding metrics** - use `getCurrentFundingMetrics()`, never duplicate
-3. **Caching** - use `getProject()` from `@/lib/projects`
-4. **CLI commands** - output XDR, never auto-sign
-5. **IPFS upload** - only via PinataService
-6. **Testing** - ManagedRuntime + dispose() in finally
-7. **Types** - distinguish `ProjectData` vs `ProjectDataWithResults`
+3. **Caching** - use `withStaleFallback` from `@/lib/cache` (SWR, serves stale on error); `getProject()`/`getProjects()` from `@/lib/projects` are the canonical callers
+4. **External I/O retry** - wrap every Stellar/IPFS `Effect.tryPromise` in `retryTransient` from `@/lib/stellar/retry` (4 attempts, exponential backoff)
+5. **Error → null discipline** - return `null` from `getProject` ONLY for real "not found" (no manageData entry, no P-token). NEVER add blanket `Effect.catchAll(() => null)` — let transient errors propagate so SWR can serve stale and `error.tsx` can render 500 instead of a misleading 404
+6. **CLI commands** - output XDR, never auto-sign
+7. **IPFS upload** - only via PinataService
+8. **Logging** - `Effect.log` only, never `Effect.logWarning` or `console.log`
+9. **Testing** - ManagedRuntime + dispose() in finally
+10. **Types** - distinguish `ProjectData` vs `ProjectDataWithResults`
 
 ## Documentation
 
@@ -171,5 +175,7 @@ test("test", async () => {
 ## Common Issues
 
 1. **Closed projects show zero** - Use `getCurrentFundingMetrics()` (see `/docs/guides/funding-metrics.md`)
-2. **Duplicate caching** - Use `getProject()` from `@/lib/projects`
+2. **Duplicate caching** - Use `getProject()`/`getProjects()` from `@/lib/projects` (not a new `withCache` wrapper — the old one was replaced by `withStaleFallback`)
 3. **Optional field errors** - Use conditional spread: `{ ...(condition ? { field: value } : {}) }`
+4. **Intermittent 404 on project pages** - Usually Pinata IPFS gateway rate-limiting (HTTP 429). Never reintroduce `catchAll(() => null)` in the fetch path; trust `retryTransient` + `withStaleFallback` to handle it (issue #6, fixed in PR #8)
+5. **Pinata public gateway is rate-limited** - Aggressive HTTP 429s under real traffic. Any new `fetch("gateway.pinata.cloud/...")` MUST go through `retryTransient`

--- a/apps/crowd.mtla.me/src/app/[code]/error.tsx
+++ b/apps/crowd.mtla.me/src/app/[code]/error.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+import { useEffect } from "react";
+
+interface ErrorPageProps {
+  readonly error: Error & { digest?: string };
+  readonly reset: () => void;
+}
+
+export default function ProjectErrorPage({ error, reset }: ErrorPageProps) {
+  useEffect(() => {
+    console.error("[crowd.mtla.me] project page error:", error);
+  }, [error]);
+
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center">
+      <div className="text-center max-w-md mx-auto px-6">
+        <div className="mb-8">
+          <h1 className="text-6xl font-black text-destructive uppercase tracking-tighter mb-4">
+            500
+          </h1>
+          <h2 className="text-2xl font-bold text-foreground uppercase mb-4">
+            PROJECT LOAD FAILED
+          </h2>
+          <p className="text-lg font-mono text-muted-foreground mb-4">
+            The project exists, but we couldn&apos;t reach the data source right now.
+          </p>
+          <p className="text-sm font-mono text-muted-foreground mb-8">
+            This is usually a transient Stellar Horizon or IPFS gateway hiccup. Try again in a moment.
+          </p>
+          {error.digest !== undefined && (
+            <p className="text-xs font-mono text-muted-foreground break-all mb-8">
+              REF: {error.digest}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-4">
+          <Button
+            size="lg"
+            className="w-full text-xl py-4"
+            onClick={() => reset()}
+          >
+            RETRY
+          </Button>
+
+          <Link href="/">
+            <Button
+              size="lg"
+              variant="outline"
+              className="w-full text-xl py-4"
+            >
+              BACK TO PROJECTS
+            </Button>
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/crowd.mtla.me/src/lib/cache.ts
+++ b/apps/crowd.mtla.me/src/lib/cache.ts
@@ -1,67 +1,74 @@
 import { Effect, pipe } from "effect";
 
-interface CacheEntry<T> {
-  data: T;
-  timestamp: number;
-  ttl: number;
+/**
+ * Stale-while-revalidate cache for Effect programs.
+ *
+ * Behavior:
+ * - Fresh hit (age < freshMs)  → return cached value, skip fetch
+ * - Stale or miss              → run the fetch effect
+ *     - on success             → update cache, return fresh value
+ *     - on failure:
+ *         - if cache has any entry (even ancient) → serve stale + log
+ *         - otherwise                             → propagate the error
+ *
+ * The cache store has no hard expiry: once a key is populated successfully,
+ * it survives indefinitely until replaced by a newer successful fetch.
+ * `freshMs` only controls when we bother re-fetching.
+ *
+ * State lives in a module-level Map, shared across the Next.js server
+ * process for the lifetime of that process (resets on cold start).
+ */
+
+interface StaleEntry<A> {
+  readonly value: A;
+  readonly timestamp: number;
 }
 
-class MemoryCache {
-  private readonly cache = new Map<string, CacheEntry<unknown>>();
-
-  set<T>(key: string, data: T, ttlMs: number = 1 * 60 * 1000): void {
-    this.cache.set(key, {
-      data,
-      timestamp: Date.now(),
-      ttl: ttlMs,
-    });
-  }
-
-  get<T>(key: string): T | null {
-    const entry = this.cache.get(key);
-
-    if (entry === undefined) {
-      return null;
-    }
-
-    if (Date.now() - entry.timestamp > entry.ttl) {
-      this.cache.delete(key);
-      return null;
-    }
-
-    return entry.data as T;
-  }
-
-  delete(key: string): void {
-    this.cache.delete(key);
-  }
-
-  clear(): void {
-    this.cache.clear();
-  }
-}
-
-// Global cache instance
-const cache = new MemoryCache();
+const store = new Map<string, StaleEntry<unknown>>();
 
 /**
- * Cache wrapper for Effect operations
+ * Wrap an Effect so that its result is cached with stale-fallback semantics.
+ *
+ * @param key     cache key (should be stable across requests for the same data)
+ * @param effect  the fetch Effect; its error channel is preserved on the "no stale" path
+ * @param freshMs duration in ms during which a cached value is returned without re-running `effect`
  */
-export const withCache = <A, E>(
-  key: Readonly<string>,
-  effect: Readonly<Effect.Effect<A, E>>,
-  ttlMs: Readonly<number> = 1 * 60 * 1000, // 1 minutes default
-): Effect.Effect<A, E> =>
+export const withStaleFallback = <A, E, R>(
+  key: string,
+  effect: Effect.Effect<A, E, R>,
+  freshMs: number,
+): Effect.Effect<A, E, R> =>
   pipe(
-    Effect.sync(() => cache.get<A>(key)),
-    Effect.flatMap(cached =>
-      cached !== null
-        ? Effect.succeed(cached)
-        : pipe(
-          effect,
-          Effect.tap(data => Effect.sync(() => cache.set(key, data, ttlMs))),
-        )
-    ),
+    Effect.sync(() => store.get(key) as StaleEntry<A> | undefined),
+    Effect.flatMap((entry) => {
+      const now = Date.now();
+
+      if (entry !== undefined && now - entry.timestamp < freshMs) {
+        return Effect.succeed(entry.value);
+      }
+
+      return pipe(
+        effect,
+        Effect.tap((value) => Effect.sync(() => store.set(key, { value, timestamp: Date.now() }))),
+        Effect.catchAll((error) => {
+          if (entry !== undefined) {
+            const ageSeconds = Math.round((now - entry.timestamp) / 1000);
+            return pipe(
+              Effect.log(
+                `[cache] stale fallback for "${key}" (age=${ageSeconds}s): ${String(error)}`,
+              ),
+              Effect.map(() => entry.value),
+            );
+          }
+          return Effect.fail(error);
+        }),
+      );
+    }),
   );
 
-export { cache };
+/**
+ * Clear the entire cache. Intended for tests and manual invalidation.
+ */
+export const clearCache = (): void => {
+  store.clear();
+};

--- a/apps/crowd.mtla.me/src/lib/cache.ts
+++ b/apps/crowd.mtla.me/src/lib/cache.ts
@@ -9,14 +9,26 @@ import { Effect, pipe } from "effect";
  *     - on success             → update cache, return fresh value
  *     - on failure:
  *         - if cache has any entry (even ancient) → serve stale + log
- *         - otherwise                             → propagate the error
+ *         - otherwise                             → log and propagate the error
  *
  * The cache store has no hard expiry: once a key is populated successfully,
  * it survives indefinitely until replaced by a newer successful fetch.
  * `freshMs` only controls when we bother re-fetching.
  *
- * State lives in a module-level Map, shared across the Next.js server
- * process for the lifetime of that process (resets on cold start).
+ * Scope:
+ * - Server-only; this module must never be imported from client bundles.
+ * - State lives in a module-level Map shared across the Next.js server
+ *   process for the lifetime of that process (resets on cold start).
+ * - In a multi-instance deployment each instance has its own copy, so
+ *   stale values may diverge across replicas — acceptable for the
+ *   best-effort use case this cache serves.
+ *
+ * Key discipline:
+ * - Callers must use stable, namespaced keys (`project-<CODE>`,
+ *   `account-name-<ID>`, …). The store is `Map<string, StaleEntry<unknown>>`
+ *   and the value shape is narrowed by an unchecked `as` cast on read;
+ *   reusing the same key with different value types will silently corrupt
+ *   subsequent reads.
  */
 
 interface StaleEntry<A> {
@@ -29,42 +41,46 @@ const store = new Map<string, StaleEntry<unknown>>();
 /**
  * Wrap an Effect so that its result is cached with stale-fallback semantics.
  *
- * @param key     cache key (should be stable across requests for the same data)
- * @param effect  the fetch Effect; its error channel is preserved on the "no stale" path
- * @param freshMs duration in ms during which a cached value is returned without re-running `effect`
+ * Curried shape — the effect is the final argument so `withStaleFallback(key, freshMs)`
+ * drops cleanly into the end of a `pipe(…)` chain alongside combinators like
+ * `Effect.retry` and `Effect.provide`.
+ *
+ * @param key     cache key (must be stable across requests for the same value shape)
+ * @param freshMs duration in ms during which a cached value is returned without re-running the effect
  */
-export const withStaleFallback = <A, E, R>(
-  key: string,
-  effect: Effect.Effect<A, E, R>,
-  freshMs: number,
-): Effect.Effect<A, E, R> =>
-  pipe(
-    Effect.sync(() => store.get(key) as StaleEntry<A> | undefined),
-    Effect.flatMap((entry) => {
-      const now = Date.now();
+export const withStaleFallback =
+  (key: string, freshMs: number) => <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
+    pipe(
+      // Key→A binding is conventional; see module docstring on "Key discipline".
+      Effect.sync(() => store.get(key) as StaleEntry<A> | undefined),
+      Effect.flatMap((entry) => {
+        const now = Date.now();
 
-      if (entry !== undefined && now - entry.timestamp < freshMs) {
-        return Effect.succeed(entry.value);
-      }
+        if (entry !== undefined && now - entry.timestamp < freshMs) {
+          return Effect.succeed(entry.value);
+        }
 
-      return pipe(
-        effect,
-        Effect.tap((value) => Effect.sync(() => store.set(key, { value, timestamp: Date.now() }))),
-        Effect.catchAll((error) => {
-          if (entry !== undefined) {
-            const ageSeconds = Math.round((now - entry.timestamp) / 1000);
+        return pipe(
+          effect,
+          Effect.tap((value) => Effect.sync(() => store.set(key, { value, timestamp: Date.now() }))),
+          Effect.catchAll((error) => {
+            if (entry !== undefined) {
+              const ageSeconds = Math.round((now - entry.timestamp) / 1000);
+              return pipe(
+                Effect.log(
+                  `[cache] stale fallback for "${key}" (age=${ageSeconds}s): ${String(error)}`,
+                ),
+                Effect.map(() => entry.value),
+              );
+            }
             return pipe(
-              Effect.log(
-                `[cache] stale fallback for "${key}" (age=${ageSeconds}s): ${String(error)}`,
-              ),
-              Effect.map(() => entry.value),
+              Effect.log(`[cache] no stale entry for "${key}", propagating: ${String(error)}`),
+              Effect.flatMap(() => Effect.fail(error)),
             );
-          }
-          return Effect.fail(error);
-        }),
-      );
-    }),
-  );
+          }),
+        );
+      }),
+    );
 
 /**
  * Clear the entire cache. Intended for tests and manual invalidation.

--- a/apps/crowd.mtla.me/src/lib/projects.ts
+++ b/apps/crowd.mtla.me/src/lib/projects.ts
@@ -19,7 +19,7 @@ export const getProjects = async (): Promise<ProjectInfo[]> => {
       return yield* stellarService.getProjects();
     }),
     Effect.provide(StellarServiceLive),
-    (effect) => withStaleFallback("projects", effect, PROJECT_FRESH_MS),
+    withStaleFallback("projects", PROJECT_FRESH_MS),
   );
 
   return Effect.runPromise(program);
@@ -35,14 +35,13 @@ export const getProjects = async (): Promise<ProjectInfo[]> => {
  * rendered as a 500 page.
  */
 export const getProject = async (code: string): Promise<ProjectInfo | null> => {
-  const key = `project-${code.toUpperCase()}`;
   const program = pipe(
     Effect.gen(function*() {
       const stellarService = yield* StellarServiceTag;
       return yield* stellarService.getProject(code);
     }),
     Effect.provide(StellarServiceLive),
-    (effect) => withStaleFallback(key, effect, PROJECT_FRESH_MS),
+    withStaleFallback(`project-${code.toUpperCase()}`, PROJECT_FRESH_MS),
   );
 
   return Effect.runPromise(program);

--- a/apps/crowd.mtla.me/src/lib/projects.ts
+++ b/apps/crowd.mtla.me/src/lib/projects.ts
@@ -1,73 +1,49 @@
 import { Effect, pipe } from "effect";
-import { withCache } from "./cache";
+import { withStaleFallback } from "./cache";
 import { type ProjectInfo, StellarServiceLive, StellarServiceTag } from "./stellar";
 
-/**
- * Cached project fetching service
- */
-export const getProjectsWithCache = (): Effect.Effect<ProjectInfo[], never> =>
-  pipe(
-    withCache(
-      "projects",
-      pipe(
-        Effect.gen(function*() {
-          const stellarService = yield* StellarServiceTag;
-          return yield* stellarService.getProjects();
-        }),
-        Effect.provide(StellarServiceLive),
-      ),
-      60 * 1000, // 1 minutes cache
-    ),
-    Effect.catchAll(() => Effect.succeed([])), // Return empty array on error
-  );
+const PROJECT_FRESH_MS = 60 * 1000; // 1 minute
 
 /**
- * Cached single project fetching service
- */
-export const getProjectWithCache = (code: string): Effect.Effect<ProjectInfo | null, never> =>
-  pipe(
-    withCache(
-      `project-${code.toUpperCase()}`,
-      pipe(
-        Effect.gen(function*() {
-          const stellarService = yield* StellarServiceTag;
-          return yield* stellarService.getProject(code);
-        }),
-        Effect.provide(StellarServiceLive),
-      ),
-      60 * 1000, // 1 minutes cache
-    ),
-    Effect.catchAll(() => Effect.succeed(null)), // Return null on error
-  );
-
-/**
- * Server-side function to get projects data
- * This should be called from server components or API routes
+ * Server-side function to get the list of all projects.
+ *
+ * Cached with stale-fallback: if the live fetch fails but a previous
+ * successful result exists, the old list is served and the failure is
+ * logged. Only a complete failure with no prior cache propagates as an
+ * error (and will trigger the Next.js error boundary → 500 page).
  */
 export const getProjects = async (): Promise<ProjectInfo[]> => {
-  const program = getProjectsWithCache();
+  const program = pipe(
+    Effect.gen(function*() {
+      const stellarService = yield* StellarServiceTag;
+      return yield* stellarService.getProjects();
+    }),
+    Effect.provide(StellarServiceLive),
+    (effect) => withStaleFallback("projects", effect, PROJECT_FRESH_MS),
+  );
 
-  try {
-    // Run the Effect program directly
-    return await Effect.runPromise(program);
-  } catch (error) {
-    console.error("Failed to fetch projects:", error);
-    return [];
-  }
+  return Effect.runPromise(program);
 };
 
 /**
- * Server-side function to get single project data
- * This should be called from server components or API routes
+ * Server-side function to get a single project by code.
+ *
+ * Returns `null` only for a real "project not found" result from the
+ * Stellar service (no matching manageData entry, or no P-token issued).
+ * Transient fetch failures are absorbed by `withStaleFallback` when a
+ * previous successful result exists, otherwise they propagate and are
+ * rendered as a 500 page.
  */
 export const getProject = async (code: string): Promise<ProjectInfo | null> => {
-  const program = getProjectWithCache(code);
+  const key = `project-${code.toUpperCase()}`;
+  const program = pipe(
+    Effect.gen(function*() {
+      const stellarService = yield* StellarServiceTag;
+      return yield* stellarService.getProject(code);
+    }),
+    Effect.provide(StellarServiceLive),
+    (effect) => withStaleFallback(key, effect, PROJECT_FRESH_MS),
+  );
 
-  try {
-    // Run the Effect program directly
-    return await Effect.runPromise(program);
-  } catch (error) {
-    console.error("Failed to fetch project:", error);
-    return null;
-  }
+  return Effect.runPromise(program);
 };

--- a/apps/crowd.mtla.me/src/lib/stellar/retry.ts
+++ b/apps/crowd.mtla.me/src/lib/stellar/retry.ts
@@ -4,17 +4,32 @@ import { Effect, pipe, Schedule } from "effect";
  * Retry policy for transient external-service failures (Stellar Horizon,
  * IPFS gateway, account name lookups).
  *
- * Exponential backoff with a hard recurrence cap: 4 attempts total
- * (the initial call + 3 retries) with delays of roughly 250ms, 500ms, 1000ms.
- * Worst-case added latency on a fully-failing call is ~1.75s.
+ * Exponential backoff with a hard recurrence cap: `MAX_ATTEMPTS` total
+ * (the initial call + `MAX_ATTEMPTS - 1` retries) with delays of roughly
+ * 250ms, 500ms, 1000ms. Worst-case added latency on a fully-failing call
+ * is ~1.75s.
  *
  * Applied per external call so that a slow IPFS request does not drag
  * Horizon calls into additional retries.
  */
+const MAX_ATTEMPTS = 4;
+
 const transientRetrySchedule = Schedule.intersect(
   Schedule.exponential("250 millis", 2.0),
-  Schedule.recurs(3),
+  Schedule.recurs(MAX_ATTEMPTS - 1),
 );
+
+/**
+ * Extract a short descriptor from an unknown error for log lines.
+ * Surfaces `StellarError.operation` when present so the retry log
+ * points at the failing call without having to dig into the cause JSON.
+ */
+const describeError = (err: unknown): string => {
+  if (typeof err === "object" && err !== null && "_tag" in err && "operation" in err) {
+    return `${String(err._tag)}(${String(err.operation)})`;
+  }
+  return String(err);
+};
 
 /**
  * Wrap an Effect with the transient retry schedule. All errors are retried
@@ -27,5 +42,5 @@ export const retryTransient = <A, E, R>(
   pipe(
     effect,
     Effect.retry(transientRetrySchedule),
-    Effect.tapError((err) => Effect.log(`[retry] giving up after 4 attempts: ${String(err)}`)),
+    Effect.tapError((err) => Effect.log(`[retry] giving up after ${MAX_ATTEMPTS} attempts: ${describeError(err)}`)),
   );

--- a/apps/crowd.mtla.me/src/lib/stellar/retry.ts
+++ b/apps/crowd.mtla.me/src/lib/stellar/retry.ts
@@ -1,0 +1,31 @@
+import { Effect, pipe, Schedule } from "effect";
+
+/**
+ * Retry policy for transient external-service failures (Stellar Horizon,
+ * IPFS gateway, account name lookups).
+ *
+ * Exponential backoff with a hard recurrence cap: 4 attempts total
+ * (the initial call + 3 retries) with delays of roughly 250ms, 500ms, 1000ms.
+ * Worst-case added latency on a fully-failing call is ~1.75s.
+ *
+ * Applied per external call so that a slow IPFS request does not drag
+ * Horizon calls into additional retries.
+ */
+const transientRetrySchedule = Schedule.intersect(
+  Schedule.exponential("250 millis", 2.0),
+  Schedule.recurs(3),
+);
+
+/**
+ * Wrap an Effect with the transient retry schedule. All errors are retried
+ * uniformly; we only invoke this for external I/O where any failure is
+ * considered potentially transient.
+ */
+export const retryTransient = <A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> =>
+  pipe(
+    effect,
+    Effect.retry(transientRetrySchedule),
+    Effect.tapError((err) => Effect.log(`[retry] giving up after 4 attempts: ${String(err)}`)),
+  );

--- a/apps/crowd.mtla.me/src/lib/stellar/service.ts
+++ b/apps/crowd.mtla.me/src/lib/stellar/service.ts
@@ -3,7 +3,7 @@ import { Context, Effect, Layer, pipe } from "effect";
 import { getStellarConfig, type StellarConfig } from "./config";
 import { StellarError, type StellarServiceError } from "./errors";
 import { retryTransient } from "./retry";
-import type { ProjectData, ProjectInfo, SupporterContributionExact } from "./types";
+import type { ProjectInfo, SupporterContributionExact } from "./types";
 import {
   enrichSupportersWithNames,
   fetchProjectDataFromIPFS,
@@ -110,17 +110,13 @@ const checkTokenExists = (
     Effect.flatMap((foundInClaimable) =>
       foundInClaimable
         ? Effect.succeed(true)
-        : pipe(
-          checkAccountBalancesForToken(server, publicKey, assetCode),
-          Effect.catchAll((error) =>
-            pipe(
-              Effect.logDebug(
-                `Account ${publicKey.slice(0, 8)}... not found or no token ${assetCode}: ${String(error)}`,
-              ),
-              Effect.map(() => false),
-            )
-          ),
-        )
+        // Fallback path: errors must propagate. Converting them to `false`
+        // here would silently turn a transient Horizon failure into a
+        // misleading "project not found" → 404, the exact bug class fixed
+        // in #6. The issuer account always exists (we just loaded its
+        // data_attr to find this token), so a real "no such account" 404
+        // here would be a configuration bug, not a normal absence.
+        : checkAccountBalancesForToken(server, publicKey, assetCode)
     ),
   );
 
@@ -218,316 +214,268 @@ export const StellarServiceLive = Layer.succeed(
       pipe(
         getStellarConfig(),
         Effect.flatMap((config: Readonly<StellarConfig>) =>
-          retryTransient(
-            Effect.tryPromise({
-              try: async () => {
-                const account = await config.server.loadAccount(config.publicKey);
-                return account.data_attr;
-              },
-              catch: (error) =>
-                new StellarError({
-                  cause: error,
-                  operation: "load_account",
+          pipe(
+            retryTransient(
+              Effect.tryPromise({
+                try: async () => {
+                  const account = await config.server.loadAccount(config.publicKey);
+                  return account.data_attr;
+                },
+                catch: (error) =>
+                  new StellarError({
+                    cause: error,
+                    operation: "load_account",
+                  }),
+              }),
+            ),
+            Effect.flatMap((dataEntries: Readonly<Record<string, string>>) => {
+              // Find project entry by code (case insensitive)
+              const normalizedCode = code.toUpperCase();
+              const projectEntry = Object.entries(dataEntries)
+                .filter(([key]: readonly [string, string]) => key.startsWith("ipfshash-"))
+                .map(([key, value]: readonly [string, string]) => {
+                  const fullCode = key.replace("ipfshash-", "");
+                  const baseCode = fullCode.startsWith("P") ? fullCode.slice(1) : fullCode;
+                  return {
+                    code: baseCode,
+                    fullCode,
+                    cid: Buffer.from(value, "base64").toString(),
+                  };
+                })
+                .find((entry: Readonly<{ code: string; fullCode: string; cid: string }>) =>
+                  entry.code.toUpperCase() === normalizedCode
+                );
+
+              if (projectEntry === undefined) {
+                return Effect.succeed(null);
+              }
+
+              return pipe(
+                Effect.all([
+                  fetchProjectDataFromIPFS(projectEntry.cid),
+                  checkTokenExists(config.server, config.publicKey, projectEntry.fullCode),
+                  getClaimableBalances(config.server, config.publicKey),
+                  checkActiveSellOffer(config.server, config.publicKey, `C${projectEntry.code}`),
+                ]),
+                Effect.flatMap(([projectData, tokenExists, claimableBalances, hasActiveSellOffer]) => {
+                  if (!tokenExists) {
+                    return Effect.succeed(null);
+                  }
+
+                  // Get funding metrics (IPFS priority for closed projects)
+                  const metrics = getCurrentFundingMetrics(
+                    projectData,
+                    claimableBalances,
+                    projectEntry.code,
+                    config.publicKey,
+                  );
+
+                  const isExpired = isProjectExpired(projectData.deadline);
+                  const isFullyFunded = parseFloat(metrics.amount) >= parseFloat(projectData.target_amount);
+
+                  // Determine status based on funding_status from IPFS data
+                  let status: "active" | "completed" | "canceled" | "expired";
+                  if ("funding_status" in projectData && projectData.funding_status !== undefined) {
+                    // Use funding_status from IPFS if available
+                    status = projectData.funding_status;
+                  } else if (isExpired || isFullyFunded || !hasActiveSellOffer) {
+                    // Legacy: project is completed if expired, fully funded, or offer closed
+                    status = "completed";
+                  } else {
+                    status = "active";
+                  }
+
+                  // Get top supporters and account names (IPFS priority for closed projects)
+                  return pipe(
+                    Effect.all([
+                      getTopSupporters(
+                        config,
+                        projectData,
+                        claimableBalances,
+                        projectEntry.code,
+                        config.publicKey,
+                        10,
+                      ),
+                      getAccountName(config, projectData.contact_account_id),
+                      getAccountName(config, projectData.project_account_id),
+                    ]),
+                    Effect.map(([topSupporters, contactName, projectName]) => {
+                      const createdAt = getProjectCreatedAt(claimableBalances, projectEntry.code, config.publicKey);
+
+                      const baseProjectInfo = {
+                        name: projectData.name,
+                        code: projectData.code,
+                        description: projectData.description,
+                        fulldescription: projectData.fulldescription,
+                        contact_account_id: projectData.contact_account_id,
+                        project_account_id: projectData.project_account_id,
+                        target_amount: projectData.target_amount,
+                        deadline: projectData.deadline,
+                        current_amount: metrics.amount,
+                        supporters_count: metrics.supporters,
+                        ipfsUrl: `https://gateway.pinata.cloud/ipfs/${projectEntry.cid}`,
+                        status,
+                        funded_amount: "funded_amount" in projectData
+                          ? (projectData.funded_amount as string)
+                          : undefined,
+                        remaining_amount: "remaining_amount" in projectData
+                          ? (projectData.remaining_amount as string)
+                          : undefined,
+                        funding_status: "funding_status" in projectData
+                          ? (projectData.funding_status as "completed" | "canceled")
+                          : undefined,
+                        ...(contactName !== undefined ? { contact_name: contactName } : {}),
+                        ...(projectName !== undefined ? { project_name: projectName } : {}),
+                        ...(createdAt !== undefined ? { created_at: createdAt } : {}),
+                      };
+
+                      const projectInfo: ProjectInfo = topSupporters.length > 0
+                        ? { ...baseProjectInfo, supporters: topSupporters }
+                        : baseProjectInfo;
+
+                      return projectInfo;
+                    }),
+                  );
                 }),
+              );
             }),
           )
         ),
-        Effect.flatMap((dataEntries: Readonly<Record<string, string>>) => {
-          // Find project entry by code (case insensitive)
-          const normalizedCode = code.toUpperCase();
-          const projectEntry = Object.entries(dataEntries)
-            .filter(([key]: readonly [string, string]) => key.startsWith("ipfshash-"))
-            .map(([key, value]: readonly [string, string]) => {
-              const fullCode = key.replace("ipfshash-", "");
-              const baseCode = fullCode.startsWith("P") ? fullCode.slice(1) : fullCode;
-              return {
-                code: baseCode,
-                fullCode,
-                cid: Buffer.from(value, "base64").toString(),
-              };
-            })
-            .find((entry: Readonly<{ code: string; fullCode: string; cid: string }>) =>
-              entry.code.toUpperCase() === normalizedCode
-            );
-
-          if (projectEntry === undefined) {
-            return Effect.succeed(null);
-          }
-
-          return pipe(
-            Effect.all([
-              fetchProjectDataFromIPFS(projectEntry.cid),
-              pipe(
-                getStellarConfig(),
-                Effect.flatMap((config: Readonly<StellarConfig>) =>
-                  checkTokenExists(config.server, config.publicKey, projectEntry.fullCode)
-                ),
-              ),
-              pipe(
-                getStellarConfig(),
-                Effect.flatMap((config: Readonly<StellarConfig>) =>
-                  getClaimableBalances(config.server, config.publicKey)
-                ),
-              ),
-              pipe(
-                getStellarConfig(),
-                Effect.flatMap((config: Readonly<StellarConfig>) =>
-                  checkActiveSellOffer(config.server, config.publicKey, `C${projectEntry.code}`)
-                ),
-              ),
-              getStellarConfig(),
-            ]),
-            Effect.flatMap(
-              (
-                [projectData, tokenExists, claimableBalances, hasActiveSellOffer, config]: readonly [
-                  ProjectData,
-                  boolean,
-                  readonly Horizon.ServerApi.ClaimableBalanceRecord[],
-                  boolean,
-                  StellarConfig,
-                ],
-              ) => {
-                if (!tokenExists) {
-                  return Effect.succeed(null);
-                }
-
-                // Get funding metrics (IPFS priority for closed projects)
-                const metrics = getCurrentFundingMetrics(
-                  projectData,
-                  claimableBalances,
-                  projectEntry.code,
-                  config.publicKey,
-                );
-
-                const isExpired = isProjectExpired(projectData.deadline);
-                const isFullyFunded = parseFloat(metrics.amount) >= parseFloat(projectData.target_amount);
-
-                // Determine status based on funding_status from IPFS data
-                let status: "active" | "completed" | "canceled" | "expired";
-                if ("funding_status" in projectData && projectData.funding_status !== undefined) {
-                  // Use funding_status from IPFS if available
-                  status = projectData.funding_status as "completed" | "canceled";
-                } else if (isExpired || isFullyFunded || !hasActiveSellOffer) {
-                  // Legacy: project is completed if expired, fully funded, or offer closed
-                  status = "completed";
-                } else {
-                  status = "active";
-                }
-
-                // Get top supporters and account names (IPFS priority for closed projects)
-                return pipe(
-                  Effect.all([
-                    getTopSupporters(
-                      config,
-                      projectData,
-                      claimableBalances,
-                      projectEntry.code,
-                      config.publicKey,
-                      10,
-                    ),
-                    getAccountName(config, projectData.contact_account_id),
-                    getAccountName(config, projectData.project_account_id),
-                  ]),
-                  Effect.map(([topSupporters, contactName, projectName]) => {
-                    const createdAt = getProjectCreatedAt(claimableBalances, projectEntry.code, config.publicKey);
-
-                    const baseProjectInfo = {
-                      name: projectData.name,
-                      code: projectData.code,
-                      description: projectData.description,
-                      fulldescription: projectData.fulldescription,
-                      contact_account_id: projectData.contact_account_id,
-                      project_account_id: projectData.project_account_id,
-                      target_amount: projectData.target_amount,
-                      deadline: projectData.deadline,
-                      current_amount: metrics.amount,
-                      supporters_count: metrics.supporters,
-                      ipfsUrl: `https://gateway.pinata.cloud/ipfs/${projectEntry.cid}`,
-                      status,
-                      funded_amount: "funded_amount" in projectData ? (projectData.funded_amount as string) : undefined,
-                      remaining_amount: "remaining_amount" in projectData
-                        ? (projectData.remaining_amount as string)
-                        : undefined,
-                      funding_status: "funding_status" in projectData
-                        ? (projectData.funding_status as "completed" | "canceled")
-                        : undefined,
-                      ...(contactName !== undefined ? { contact_name: contactName } : {}),
-                      ...(projectName !== undefined ? { project_name: projectName } : {}),
-                      ...(createdAt !== undefined ? { created_at: createdAt } : {}),
-                    };
-
-                    const projectInfo: ProjectInfo = topSupporters.length > 0
-                      ? { ...baseProjectInfo, supporters: topSupporters }
-                      : baseProjectInfo;
-
-                    return projectInfo;
-                  }),
-                );
-              },
-            ),
-          );
-        }),
       ),
 
     getProjects: () =>
       pipe(
         getStellarConfig(),
         Effect.flatMap((config: Readonly<StellarConfig>) =>
-          retryTransient(
-            Effect.tryPromise({
-              try: async () => {
-                const account = await config.server.loadAccount(config.publicKey);
-                return account.data_attr;
-              },
-              catch: (error) =>
-                new StellarError({
-                  cause: error,
-                  operation: "load_account",
-                }),
+          pipe(
+            retryTransient(
+              Effect.tryPromise({
+                try: async () => {
+                  const account = await config.server.loadAccount(config.publicKey);
+                  return account.data_attr;
+                },
+                catch: (error) =>
+                  new StellarError({
+                    cause: error,
+                    operation: "load_account",
+                  }),
+              }),
+            ),
+            Effect.flatMap((dataEntries: Readonly<Record<string, string>>) => {
+              const projectEntries = Object.entries(dataEntries)
+                .filter(([key]: readonly [string, string]) => key.startsWith("ipfshash-"))
+                .map(([key, value]: readonly [string, string]) => {
+                  const fullCode = key.replace("ipfshash-", "");
+                  // Remove P prefix to get base project code (e.g., PRHODESIA -> RHODESIA)
+                  const baseCode = fullCode.startsWith("P") ? fullCode.slice(1) : fullCode;
+                  return {
+                    code: baseCode,
+                    fullCode, // Keep original P-token name for checkTokenExists
+                    cid: Buffer.from(value, "base64").toString(),
+                  };
+                });
+
+              return Effect.all(
+                projectEntries.map((entry: Readonly<{ code: string; fullCode: string; cid: string }>) =>
+                  pipe(
+                    Effect.all([
+                      fetchProjectDataFromIPFS(entry.cid),
+                      checkTokenExists(config.server, config.publicKey, entry.fullCode),
+                      getClaimableBalances(config.server, config.publicKey),
+                      checkActiveSellOffer(config.server, config.publicKey, `C${entry.code}`),
+                    ]),
+                    Effect.flatMap(([projectData, tokenExists, claimableBalances, hasActiveSellOffer]) => {
+                      if (!tokenExists) {
+                        return Effect.succeed(null); // Skip projects without P-tokens (project doesn't exist)
+                      }
+
+                      // Get funding metrics (IPFS priority for closed projects)
+                      const metrics = getCurrentFundingMetrics(
+                        projectData,
+                        claimableBalances,
+                        entry.code,
+                        config.publicKey,
+                      );
+
+                      const isExpired = isProjectExpired(projectData.deadline);
+                      const isFullyFunded = parseFloat(metrics.amount) >= parseFloat(projectData.target_amount);
+
+                      // Determine status based on funding_status from IPFS data
+                      let status: "active" | "completed" | "canceled" | "expired";
+                      if ("funding_status" in projectData && projectData.funding_status !== undefined) {
+                        // Use funding_status from IPFS if available
+                        status = projectData.funding_status;
+                      } else if (isExpired || isFullyFunded || !hasActiveSellOffer) {
+                        // Legacy: project is completed if expired, fully funded, or offer closed
+                        status = "completed";
+                      } else {
+                        status = "active";
+                      }
+
+                      const createdAt = getProjectCreatedAt(claimableBalances, entry.code, config.publicKey);
+
+                      const baseProjectInfo = {
+                        name: projectData.name,
+                        code: projectData.code,
+                        description: projectData.description,
+                        fulldescription: projectData.fulldescription,
+                        contact_account_id: projectData.contact_account_id,
+                        project_account_id: projectData.project_account_id,
+                        target_amount: projectData.target_amount,
+                        deadline: projectData.deadline,
+                        current_amount: metrics.amount,
+                        supporters_count: metrics.supporters,
+                        ipfsUrl: `https://gateway.pinata.cloud/ipfs/${entry.cid}`,
+                        status,
+                        funded_amount: "funded_amount" in projectData
+                          ? (projectData.funded_amount as string)
+                          : undefined,
+                        remaining_amount: "remaining_amount" in projectData
+                          ? (projectData.remaining_amount as string)
+                          : undefined,
+                        funding_status: "funding_status" in projectData
+                          ? (projectData.funding_status as "completed" | "canceled")
+                          : undefined,
+                        ...(createdAt !== undefined ? { created_at: createdAt } : {}),
+                      };
+
+                      // Enrich supporters with names if needed (fallback for old projects)
+                      // enrichSupportersWithNames is best-effort (Effect<_, never>),
+                      // so no error-channel handling is needed here.
+                      if ("supporters" in projectData && projectData.supporters !== undefined) {
+                        return pipe(
+                          enrichSupportersWithNames(
+                            config,
+                            projectData.supporters as readonly SupporterContributionExact[],
+                          ),
+                          Effect.map((enrichedSupporters) => ({
+                            ...baseProjectInfo,
+                            supporters: enrichedSupporters,
+                          })),
+                        );
+                      }
+
+                      return Effect.succeed(baseProjectInfo);
+                    }),
+                    Effect.catchAll((error) =>
+                      pipe(
+                        Effect.log(`[getProjects] skipping ${entry.code} after retries: ${String(error)}`),
+                        Effect.map(() => null),
+                      )
+                    ),
+                  )
+                ),
+                { concurrency: "unbounded" },
+              );
+            }),
+            Effect.map((projects: readonly (ProjectInfo | null)[]) => {
+              const validProjects = projects.filter(
+                (p: Readonly<ProjectInfo | null>): p is ProjectInfo => p !== null,
+              );
+              return sortProjectsByPriority(validProjects);
             }),
           )
         ),
-        Effect.flatMap((dataEntries: Readonly<Record<string, string>>) => {
-          const projectEntries = Object.entries(dataEntries)
-            .filter(([key]: readonly [string, string]) => key.startsWith("ipfshash-"))
-            .map(([key, value]: readonly [string, string]) => {
-              const fullCode = key.replace("ipfshash-", "");
-              // Remove P prefix to get base project code (e.g., PRHODESIA -> RHODESIA)
-              const baseCode = fullCode.startsWith("P") ? fullCode.slice(1) : fullCode;
-              return {
-                code: baseCode,
-                fullCode, // Keep original P-token name for checkTokenExists
-                cid: Buffer.from(value, "base64").toString(),
-              };
-            });
-
-          return Effect.all(
-            projectEntries.map((entry: Readonly<{ code: string; fullCode: string; cid: string }>) =>
-              pipe(
-                Effect.all([
-                  fetchProjectDataFromIPFS(entry.cid),
-                  pipe(
-                    getStellarConfig(),
-                    Effect.flatMap((config: Readonly<StellarConfig>) =>
-                      checkTokenExists(config.server, config.publicKey, entry.fullCode)
-                    ),
-                  ),
-                  pipe(
-                    getStellarConfig(),
-                    Effect.flatMap((config: Readonly<StellarConfig>) =>
-                      getClaimableBalances(config.server, config.publicKey)
-                    ),
-                  ),
-                  pipe(
-                    getStellarConfig(),
-                    Effect.flatMap((config: Readonly<StellarConfig>) =>
-                      checkActiveSellOffer(config.server, config.publicKey, `C${entry.code}`)
-                    ),
-                  ),
-                  getStellarConfig(),
-                ]),
-                Effect.flatMap(
-                  (
-                    [projectData, tokenExists, claimableBalances, hasActiveSellOffer, config]: readonly [
-                      ProjectData,
-                      boolean,
-                      readonly Horizon.ServerApi.ClaimableBalanceRecord[],
-                      boolean,
-                      StellarConfig,
-                    ],
-                  ) => {
-                    if (!tokenExists) {
-                      return Effect.succeed(null); // Skip projects without P-tokens (project doesn't exist)
-                    }
-
-                    // Get funding metrics (IPFS priority for closed projects)
-                    const metrics = getCurrentFundingMetrics(
-                      projectData,
-                      claimableBalances,
-                      entry.code,
-                      config.publicKey,
-                    );
-
-                    const isExpired = isProjectExpired(projectData.deadline);
-                    const isFullyFunded = parseFloat(metrics.amount) >= parseFloat(projectData.target_amount);
-
-                    // Determine status based on funding_status from IPFS data
-                    let status: "active" | "completed" | "canceled" | "expired";
-                    if ("funding_status" in projectData && projectData.funding_status !== undefined) {
-                      // Use funding_status from IPFS if available
-                      status = projectData.funding_status as "completed" | "canceled";
-                    } else if (isExpired || isFullyFunded || !hasActiveSellOffer) {
-                      // Legacy: project is completed if expired, fully funded, or offer closed
-                      status = "completed";
-                    } else {
-                      status = "active";
-                    }
-
-                    const createdAt = getProjectCreatedAt(claimableBalances, entry.code, config.publicKey);
-
-                    const baseProjectInfo = {
-                      name: projectData.name,
-                      code: projectData.code,
-                      description: projectData.description,
-                      fulldescription: projectData.fulldescription,
-                      contact_account_id: projectData.contact_account_id,
-                      project_account_id: projectData.project_account_id,
-                      target_amount: projectData.target_amount,
-                      deadline: projectData.deadline,
-                      current_amount: metrics.amount,
-                      supporters_count: metrics.supporters,
-                      ipfsUrl: `https://gateway.pinata.cloud/ipfs/${entry.cid}`,
-                      status,
-                      funded_amount: "funded_amount" in projectData ? (projectData.funded_amount as string) : undefined,
-                      remaining_amount: "remaining_amount" in projectData
-                        ? (projectData.remaining_amount as string)
-                        : undefined,
-                      funding_status: "funding_status" in projectData
-                        ? (projectData.funding_status as "completed" | "canceled")
-                        : undefined,
-                      ...(createdAt !== undefined ? { created_at: createdAt } : {}),
-                    };
-
-                    // Enrich supporters with names if needed (fallback for old projects)
-                    if ("supporters" in projectData && projectData.supporters !== undefined) {
-                      return pipe(
-                        enrichSupportersWithNames(
-                          config,
-                          projectData.supporters as readonly SupporterContributionExact[],
-                        ),
-                        Effect.map((enrichedSupporters) => ({
-                          ...baseProjectInfo,
-                          supporters: enrichedSupporters,
-                        })),
-                        Effect.catchAll((error) =>
-                          pipe(
-                            Effect.log(
-                              `[getProjects] failed to enrich supporters for ${entry.code}: ${String(error)}`,
-                            ),
-                            Effect.map(() => baseProjectInfo),
-                          )
-                        ),
-                      );
-                    }
-
-                    return Effect.succeed(baseProjectInfo);
-                  },
-                ),
-                Effect.catchAll((error) =>
-                  pipe(
-                    Effect.log(`[getProjects] skipping ${entry.code} after retries: ${String(error)}`),
-                    Effect.map(() => null),
-                  )
-                ),
-              )
-            ),
-            { concurrency: "unbounded" },
-          );
-        }),
-        Effect.map((projects: readonly (ProjectInfo | null)[]) => {
-          const validProjects = projects.filter((p: Readonly<ProjectInfo | null>): p is ProjectInfo => p !== null);
-          return sortProjectsByPriority(validProjects);
-        }),
       ),
   }),
 );

--- a/apps/crowd.mtla.me/src/lib/stellar/service.ts
+++ b/apps/crowd.mtla.me/src/lib/stellar/service.ts
@@ -2,6 +2,7 @@ import type { Horizon } from "@stellar/stellar-sdk";
 import { Context, Effect, Layer, pipe } from "effect";
 import { getStellarConfig, type StellarConfig } from "./config";
 import { StellarError, type StellarServiceError } from "./errors";
+import { retryTransient } from "./retry";
 import type { ProjectData, ProjectInfo, SupporterContributionExact } from "./types";
 import {
   enrichSupportersWithNames,
@@ -28,7 +29,7 @@ const checkClaimableBalancesForToken = (
   publicKey: Readonly<string>,
   assetCode: Readonly<string>,
 ): Effect.Effect<boolean, StellarError> =>
-  pipe(
+  retryTransient(
     Effect.tryPromise({
       try: async () => {
         let callBuilder = server.claimableBalances()
@@ -73,7 +74,7 @@ const checkAccountBalancesForToken = (
   publicKey: Readonly<string>,
   assetCode: Readonly<string>,
 ): Effect.Effect<boolean, StellarError> =>
-  pipe(
+  retryTransient(
     Effect.tryPromise({
       try: async () => {
         const account = await server.loadAccount(publicKey);
@@ -128,7 +129,7 @@ const checkActiveSellOffer = (
   publicKey: Readonly<string>,
   crowdfundingTokenCode: Readonly<string>,
 ): Effect.Effect<boolean, StellarError> =>
-  pipe(
+  retryTransient(
     Effect.tryPromise({
       try: async () => {
         const allRecords: Horizon.ServerApi.OfferRecord[] = [];
@@ -172,7 +173,7 @@ const getClaimableBalances = (
   server: Readonly<Horizon.Server>,
   publicKey: Readonly<string>,
 ): Effect.Effect<readonly Horizon.ServerApi.ClaimableBalanceRecord[], StellarError> =>
-  pipe(
+  retryTransient(
     Effect.tryPromise({
       try: async () => {
         const allRecords: Horizon.ServerApi.ClaimableBalanceRecord[] = [];
@@ -217,17 +218,19 @@ export const StellarServiceLive = Layer.succeed(
       pipe(
         getStellarConfig(),
         Effect.flatMap((config: Readonly<StellarConfig>) =>
-          Effect.tryPromise({
-            try: async () => {
-              const account = await config.server.loadAccount(config.publicKey);
-              return account.data_attr;
-            },
-            catch: (error) =>
-              new StellarError({
-                cause: error,
-                operation: "load_account",
-              }),
-          })
+          retryTransient(
+            Effect.tryPromise({
+              try: async () => {
+                const account = await config.server.loadAccount(config.publicKey);
+                return account.data_attr;
+              },
+              catch: (error) =>
+                new StellarError({
+                  cause: error,
+                  operation: "load_account",
+                }),
+            }),
+          )
         ),
         Effect.flatMap((dataEntries: Readonly<Record<string, string>>) => {
           // Find project entry by code (case insensitive)
@@ -362,12 +365,6 @@ export const StellarServiceLive = Layer.succeed(
                 );
               },
             ),
-            Effect.catchAll((error) =>
-              pipe(
-                Effect.logWarning(`Failed to load project ${code}: ${String(error)}`),
-                Effect.map(() => null),
-              )
-            ),
           );
         }),
       ),
@@ -376,17 +373,19 @@ export const StellarServiceLive = Layer.succeed(
       pipe(
         getStellarConfig(),
         Effect.flatMap((config: Readonly<StellarConfig>) =>
-          Effect.tryPromise({
-            try: async () => {
-              const account = await config.server.loadAccount(config.publicKey);
-              return account.data_attr;
-            },
-            catch: (error) =>
-              new StellarError({
-                cause: error,
-                operation: "load_account",
-              }),
-          })
+          retryTransient(
+            Effect.tryPromise({
+              try: async () => {
+                const account = await config.server.loadAccount(config.publicKey);
+                return account.data_attr;
+              },
+              catch: (error) =>
+                new StellarError({
+                  cause: error,
+                  operation: "load_account",
+                }),
+            }),
+          )
         ),
         Effect.flatMap((dataEntries: Readonly<Record<string, string>>) => {
           const projectEntries = Object.entries(dataEntries)
@@ -502,8 +501,8 @@ export const StellarServiceLive = Layer.succeed(
                         })),
                         Effect.catchAll((error) =>
                           pipe(
-                            Effect.logWarning(
-                              `Failed to enrich supporters for project ${entry.code}: ${String(error)}`,
+                            Effect.log(
+                              `[getProjects] failed to enrich supporters for ${entry.code}: ${String(error)}`,
                             ),
                             Effect.map(() => baseProjectInfo),
                           )
@@ -516,7 +515,7 @@ export const StellarServiceLive = Layer.succeed(
                 ),
                 Effect.catchAll((error) =>
                   pipe(
-                    Effect.logWarning(`Failed to load project ${entry.code}: ${String(error)}`),
+                    Effect.log(`[getProjects] skipping ${entry.code} after retries: ${String(error)}`),
                     Effect.map(() => null),
                   )
                 ),

--- a/apps/crowd.mtla.me/src/lib/stellar/utils.ts
+++ b/apps/crowd.mtla.me/src/lib/stellar/utils.ts
@@ -17,72 +17,65 @@ const ACCOUNT_NAME_FRESH_MS = 24 * 60 * 60 * 1000; // 24 hours
  * returned.
  *
  * Name resolution is best-effort — a failure here must never prevent a
- * project from rendering. If both the fresh lookup and the stale cache
- * fail to produce a value, we log and return `undefined`.
- *
- * Returns the decoded name or `undefined` if the account has no Name entry.
+ * project from rendering. The error channel is therefore `never`: on any
+ * failure we log and fall back to `undefined`. This collapses three cases
+ * ("no Name entry", "transient lookup failure", "account does not exist")
+ * into a single `undefined` result; callers that need to distinguish them
+ * must not use this function.
  */
 export const getAccountName = (
   config: Readonly<StellarConfig>,
   accountId: Readonly<string>,
 ): Effect.Effect<string | undefined, never> =>
   pipe(
-    withStaleFallback(
-      `account-name-${accountId}`,
-      retryTransient(
-        Effect.tryPromise({
-          try: async () => {
-            const account = await config.server.loadAccount(accountId);
-            const nameEntry = account.data_attr["Name"];
+    Effect.tryPromise({
+      try: async () => {
+        const account = await config.server.loadAccount(accountId);
+        const nameEntry = account.data_attr["Name"];
 
-            if (nameEntry === undefined) {
-              return undefined;
-            }
+        if (nameEntry === undefined) {
+          return undefined;
+        }
 
-            return Buffer.from(nameEntry, "base64").toString("utf-8");
-          },
-          catch: (error) =>
-            new StellarError({
-              cause: error,
-              operation: "get_account_name",
-            }),
+        return Buffer.from(nameEntry, "base64").toString("utf-8");
+      },
+      catch: (error) =>
+        new StellarError({
+          cause: error,
+          operation: "get_account_name",
         }),
-      ),
-      ACCOUNT_NAME_FRESH_MS,
-    ),
-    Effect.catchAll((error) =>
-      pipe(
-        Effect.log(
-          `[getAccountName] ${accountId.slice(0, 8)}... lookup failed, returning undefined: ${String(error)}`,
-        ),
-        Effect.map(() => undefined),
+    }),
+    retryTransient,
+    withStaleFallback(`account-name-${accountId}`, ACCOUNT_NAME_FRESH_MS),
+    Effect.tapError((error) =>
+      Effect.log(
+        `[getAccountName] ${accountId.slice(0, 8)}... lookup failed, returning undefined: ${String(error)}`,
       )
     ),
+    Effect.orElseSucceed(() => undefined),
   );
 
 /**
- * Enrich supporters array with account names from Stellar manageData
- * Fetches names in parallel with caching (24h TTL in getAccountName)
- * Skips supporters that already have names for efficiency
+ * Enrich a supporters array with account names from Stellar manageData.
+ * Fetches names in parallel; skips supporters that already have one.
  *
- * @param config - Stellar configuration
- * @param supporters - Supporters array (may or may not have names)
- * @returns Effect with enriched supporters
+ * `getAccountName` is best-effort (`Effect<_, never>`) with its own
+ * `withStaleFallback` cache (24h fresh window), so this pipeline cannot
+ * fail on a single missing name — the original supporter is used as-is
+ * when no name is resolved.
  */
 export const enrichSupportersWithNames = <
   T extends { readonly account_id: string; readonly amount: string; readonly name?: string | undefined },
 >(
   config: Readonly<StellarConfig>,
   supporters: readonly T[],
-): Effect.Effect<readonly T[], StellarError> =>
+): Effect.Effect<readonly T[], never> =>
   pipe(
     Effect.all(
       supporters.map((supporter) => {
-        // Skip if already has name
         if (supporter.name !== undefined) {
           return Effect.succeed(supporter);
         }
-        // Fetch name from Horizon
         return pipe(
           getAccountName(config, supporter.account_id),
           Effect.map((name): T =>
@@ -91,21 +84,13 @@ export const enrichSupportersWithNames = <
               ...(name !== undefined ? { name } : {}),
             }) as T
           ),
-          Effect.catchAll((error) =>
-            pipe(
-              Effect.log(
-                `[enrichSupporters] failed to fetch name for ${supporter.account_id.slice(0, 8)}...: ${String(error)}`,
-              ),
-              Effect.map(() => supporter),
-            )
-          ),
         );
       }),
       { concurrency: "unbounded" },
     ),
     Effect.tap((enriched) => {
       const withNames = enriched.filter((s) => s.name !== undefined).length;
-      return Effect.logInfo(
+      return Effect.log(
         `Enriched ${withNames}/${supporters.length} supporters with names`,
       );
     }),
@@ -322,7 +307,7 @@ export const getTopSupporters = (
   assetCode: Readonly<string>,
   stellarAccountId: Readonly<string>,
   limit = 10,
-): Effect.Effect<readonly SupporterContributionExact[], StellarError> => {
+): Effect.Effect<readonly SupporterContributionExact[], never> => {
   // Check if project has finalized supporters data in IPFS
   const hasIPFSSupportersData = "supporters" in projectData
     && projectData.supporters !== undefined

--- a/apps/crowd.mtla.me/src/lib/stellar/utils.ts
+++ b/apps/crowd.mtla.me/src/lib/stellar/utils.ts
@@ -1,77 +1,64 @@
 import type { Horizon } from "@stellar/stellar-sdk";
 import { Effect, pipe } from "effect";
+import { withStaleFallback } from "../cache";
 import type { StellarConfig } from "./config";
 import { StellarError } from "./errors";
+import { retryTransient } from "./retry";
 import type { ProjectData, ProjectDataWithResults, ProjectInfo, SupporterContributionExact } from "./types";
 
-/**
- * In-memory cache for account names
- * TTL: 24 hours (86400000 ms)
- */
-interface CachedName {
-  readonly name: string | undefined;
-  readonly timestamp: number;
-}
-
-const accountNamesCache = new Map<string, CachedName>();
-const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const ACCOUNT_NAME_FRESH_MS = 24 * 60 * 60 * 1000; // 24 hours
 
 /**
- * Get account name from manageData entry "Name" with 24h caching
- * Returns decoded name or undefined if not found
+ * Get account name from manageData entry "Name".
  *
- * Cache rationale:
- * - Account names change very rarely
- * - Reduces Horizon API calls significantly
- * - 24h TTL ensures eventual consistency
+ * Uses the shared `withStaleFallback` cache with a 24h fresh window:
+ * account names change very rarely, so we keep them cached for a day.
+ * If the Horizon lookup fails transiently, an older cached value is
+ * returned.
+ *
+ * Name resolution is best-effort — a failure here must never prevent a
+ * project from rendering. If both the fresh lookup and the stale cache
+ * fail to produce a value, we log and return `undefined`.
+ *
+ * Returns the decoded name or `undefined` if the account has no Name entry.
  */
 export const getAccountName = (
   config: Readonly<StellarConfig>,
   accountId: Readonly<string>,
-): Effect.Effect<string | undefined, StellarError> => {
-  // Check cache first
-  const cached = accountNamesCache.get(accountId);
-  const now = Date.now();
+): Effect.Effect<string | undefined, never> =>
+  pipe(
+    withStaleFallback(
+      `account-name-${accountId}`,
+      retryTransient(
+        Effect.tryPromise({
+          try: async () => {
+            const account = await config.server.loadAccount(accountId);
+            const nameEntry = account.data_attr["Name"];
 
-  if (cached !== undefined && (now - cached.timestamp) < CACHE_TTL_MS) {
-    return pipe(
-      Effect.succeed(cached.name),
-      Effect.tap(() => Effect.log(`[Cache HIT] Account name for ${accountId.slice(0, 8)}...`)),
-    );
-  }
+            if (nameEntry === undefined) {
+              return undefined;
+            }
 
-  // Cache miss or expired - fetch from Horizon
-  return pipe(
-    Effect.tryPromise({
-      try: async () => {
-        const account = await config.server.loadAccount(accountId);
-        const nameEntry = account.data_attr["Name"];
-
-        if (nameEntry === undefined) {
-          return undefined;
-        }
-
-        return Buffer.from(nameEntry, "base64").toString("utf-8");
-      },
-      catch: (error) =>
-        new StellarError({
-          cause: error,
-          operation: "get_account_name",
+            return Buffer.from(nameEntry, "base64").toString("utf-8");
+          },
+          catch: (error) =>
+            new StellarError({
+              cause: error,
+              operation: "get_account_name",
+            }),
         }),
-    }),
-    Effect.tap((name) => {
-      accountNamesCache.set(accountId, { name, timestamp: now });
-      return Effect.log(`[Cache MISS] Account name for ${accountId.slice(0, 8)}...: ${name ?? "undefined"}`);
-    }),
-    Effect.catchAll(() =>
+      ),
+      ACCOUNT_NAME_FRESH_MS,
+    ),
+    Effect.catchAll((error) =>
       pipe(
-        Effect.sync(() => accountNamesCache.set(accountId, { name: undefined, timestamp: now })),
-        Effect.tap(() => Effect.log(`[Cache MISS] Account ${accountId.slice(0, 8)}... not found or has no name`)),
+        Effect.log(
+          `[getAccountName] ${accountId.slice(0, 8)}... lookup failed, returning undefined: ${String(error)}`,
+        ),
         Effect.map(() => undefined),
       )
     ),
   );
-};
 
 /**
  * Enrich supporters array with account names from Stellar manageData
@@ -106,7 +93,9 @@ export const enrichSupportersWithNames = <
           ),
           Effect.catchAll((error) =>
             pipe(
-              Effect.logWarning(`Failed to fetch name for ${supporter.account_id.slice(0, 8)}...: ${String(error)}`),
+              Effect.log(
+                `[enrichSupporters] failed to fetch name for ${supporter.account_id.slice(0, 8)}...: ${String(error)}`,
+              ),
               Effect.map(() => supporter),
             )
           ),
@@ -123,11 +112,15 @@ export const enrichSupportersWithNames = <
   );
 
 /**
- * Fetch project data from IPFS using CID
- * Returns ProjectDataWithResults which includes optional funding results
+ * Fetch project data from IPFS using CID.
+ * Returns ProjectDataWithResults which includes optional funding results.
+ *
+ * Wrapped in `retryTransient`: IPFS gateway latency and intermittent
+ * failures are the primary source of transient errors in the project
+ * fetch path, so aggressive retries pay off here the most.
  */
 export const fetchProjectDataFromIPFS = (cid: string): Effect.Effect<ProjectDataWithResults, StellarError> =>
-  pipe(
+  retryTransient(
     Effect.tryPromise({
       try: async () => {
         const ipfsUrl = `https://gateway.pinata.cloud/ipfs/${cid}`;


### PR DESCRIPTION
## Summary

- Replace hand-rolled `MemoryCache` with a `withStaleFallback` SWR helper: successful results are kept indefinitely and served as a fallback when live fetches fail, so a project that ever loaded will keep loading.
- Add a `retryTransient` wrapper (`Schedule.exponential("250 millis", 2.0) ∩ recurs(3)`, 4 attempts, ~1.75s worst case) applied per external call in `stellar/service.ts` and `stellar/utils.ts` — especially important for the slow IPFS gateway which was the primary culprit.
- Remove the stacked `Effect.catchAll(() => null)` + `try/catch` swallowing across `projects.ts` and `service.ts`. Genuine "not found" still returns `null` (no `manageData` entry or no P-token); transient errors now propagate properly instead of being misrendered as a 404.
- Unify the account-names cache onto the same `withStaleFallback` helper (24h fresh window). `getAccountName` is now explicitly best-effort (`Effect<_, never>`) so a secondary name lookup can never crash the parent project fetch.
- Add a styled `app/[code]/error.tsx` so propagated errors render a brutalist 500 page with a retry button instead of a misleading 404.
- Replace all `Effect.logWarning` with `Effect.log` per `docs/guides/effect-ts-patterns.md`.

Fixes #6.

## Test plan

- [x] `cd apps/crowd.mtla.me && bun run lint` passes
- [x] `cd apps/crowd.mtla.me && bunx tsc --noEmit` passes
- [x] `cd apps/crowd.mtla.me && bun run build` succeeds (all 10 static pages generated with live Stellar data)
- [ ] Dev: hitting an existing project page repeatedly no longer flashes the 404 screen
- [ ] Dev: simulating an IPFS gateway outage serves stale data if the project was ever loaded successfully
- [ ] Dev: simulating a permanent outage on first load renders the new styled 500 page, not a 404
- [ ] Real "project not found" (unknown code) still renders the existing 404 page

🤖 Generated with [Claude Code](https://claude.com/claude-code)