### PR TITLE
feat(stat.mtlf.me): add API endpoint switching

### DIFF
--- a/apps/stat.mtlf.me/src/components/portfolio/fund-structure-table.tsx
+++ b/apps/stat.mtlf.me/src/components/portfolio/fund-structure-table.tsx
@@ -44,7 +44,7 @@ function formatPriceTooltip(details?: PriceDetails, showOrderbookDetails = true)
             </span>
           </div>
           <div className="flex justify-between gap-4">
-            <span className="text-steel-gray uppercase font-bold">ORDERBOOK ({details.priceType.toUpperCase()}):</span>
+            <span className="text-steel-gray uppercase font-bold">ORDERBOOK{details.priceType != null ? ` (${details.priceType.toUpperCase()})` : ""}:</span>
             <span className={`${details.chosenSource === "orderbook" ? "text-cyber-green font-bold" : "text-steel-gray"}`}>
               {details.orderbookPrice !== null ? formatNumber(parseFloat(details.orderbookPrice), 7) : "—"}
             </span>
@@ -88,14 +88,14 @@ function formatPriceTooltip(details?: PriceDetails, showOrderbookDetails = true)
         {details.orderbookData !== null && details.orderbookData !== undefined && (
           <div className="text-[10px] space-y-2 pt-2 border-t border-steel-gray/30">
             {/* Best source indicator */}
-            {details.orderbookData.bestSource !== "none" && (
+            {details.orderbookData.bestSource != null && details.orderbookData.bestSource !== "none" && (
               <div className="text-electric-cyan uppercase text-[9px] font-bold">
                 BEST SOURCE: {details.orderbookData.bestSource.toUpperCase()}
               </div>
             )}
 
             {/* Orderbook prices */}
-            {(details.orderbookData.orderbook.ask !== null || details.orderbookData.orderbook.bid !== null) && (
+            {(details.orderbookData.orderbook?.ask != null || details.orderbookData.orderbook?.bid != null) && (
               <div className="space-y-0.5">
                 <div className="text-steel-gray uppercase text-[9px] font-bold">ORDERBOOK:</div>
                 <div className="flex justify-between gap-3">
@@ -103,7 +103,7 @@ function formatPriceTooltip(details?: PriceDetails, showOrderbookDetails = true)
                     ASK:
                   </span>
                   <span className={`font-mono ${details.priceType === "ask" && details.orderbookData.bestSource === "orderbook" ? "text-cyber-green" : "text-steel-gray"}`}>
-                    {details.orderbookData.orderbook.ask !== null ? formatNumber(parseFloat(details.orderbookData.orderbook.ask), 7) : "—"}
+                    {details.orderbookData.orderbook?.ask != null ? formatNumber(parseFloat(details.orderbookData.orderbook.ask), 7) : "—"}
                   </span>
                 </div>
                 <div className="flex justify-between gap-3">
@@ -111,14 +111,14 @@ function formatPriceTooltip(details?: PriceDetails, showOrderbookDetails = true)
                     BID:
                   </span>
                   <span className={`font-mono ${details.priceType === "bid" && details.orderbookData.bestSource === "orderbook" ? "text-cyber-green" : "text-steel-gray"}`}>
-                    {details.orderbookData.orderbook.bid !== null ? formatNumber(parseFloat(details.orderbookData.orderbook.bid), 7) : "—"}
+                    {details.orderbookData.orderbook?.bid != null ? formatNumber(parseFloat(details.orderbookData.orderbook.bid), 7) : "—"}
                   </span>
                 </div>
               </div>
             )}
 
             {/* AMM prices */}
-            {(details.orderbookData.amm.ask !== null || details.orderbookData.amm.bid !== null) && (
+            {(details.orderbookData.amm?.ask != null || details.orderbookData.amm?.bid != null) && (
               <div className="space-y-0.5">
                 <div className="text-steel-gray uppercase text-[9px] font-bold">AMM POOL:</div>
                 <div className="flex justify-between gap-3">
@@ -126,7 +126,7 @@ function formatPriceTooltip(details?: PriceDetails, showOrderbookDetails = true)
                     ASK:
                   </span>
                   <span className={`font-mono ${details.priceType === "ask" && details.orderbookData.bestSource === "amm" ? "text-cyber-green" : "text-steel-gray"}`}>
-                    {details.orderbookData.amm.ask !== null ? formatNumber(parseFloat(details.orderbookData.amm.ask), 7) : "—"}
+                    {details.orderbookData.amm?.ask != null ? formatNumber(parseFloat(details.orderbookData.amm.ask), 7) : "—"}
                   </span>
                 </div>
                 <div className="flex justify-between gap-3">
@@ -134,7 +134,7 @@ function formatPriceTooltip(details?: PriceDetails, showOrderbookDetails = true)
                     BID:
                   </span>
                   <span className={`font-mono ${details.priceType === "bid" && details.orderbookData.bestSource === "amm" ? "text-cyber-green" : "text-steel-gray"}`}>
-                    {details.orderbookData.amm.bid !== null ? formatNumber(parseFloat(details.orderbookData.amm.bid), 7) : "—"}
+                    {details.orderbookData.amm?.bid != null ? formatNumber(parseFloat(details.orderbookData.amm.bid), 7) : "—"}
                   </span>
                 </div>
               </div>
@@ -183,14 +183,14 @@ function formatPriceTooltip(details?: PriceDetails, showOrderbookDetails = true)
               {showOrderbookDetails && hop.orderbook !== null && hop.orderbook !== undefined && (
                 <div className="pl-2 space-y-1.5 text-[10px]">
                   {/* Best source indicator */}
-                  {hop.orderbook.bestSource !== "none" && (
+                  {hop.orderbook.bestSource != null && hop.orderbook.bestSource !== "none" && (
                     <div className="text-electric-cyan uppercase text-[9px] font-bold">
                       BEST: {hop.orderbook.bestSource.toUpperCase()}
                     </div>
                   )}
 
                   {/* Orderbook prices */}
-                  {(hop.orderbook.orderbook.ask !== null || hop.orderbook.orderbook.bid !== null) && (
+                  {(hop.orderbook.orderbook?.ask != null || hop.orderbook.orderbook?.bid != null) && (
                     <div className="space-y-0.5">
                       <div className="text-steel-gray uppercase text-[9px] font-bold">ORDERBOOK:</div>
                       <div className="flex justify-between gap-3">
@@ -198,7 +198,7 @@ function formatPriceTooltip(details?: PriceDetails, showOrderbookDetails = true)
                           ASK:
                         </span>
                         <span className={`font-mono ${hop.orderbook.bestSource === "orderbook" ? "text-cyber-green" : "text-steel-gray"}`}>
-                          {hop.orderbook.orderbook.ask !== null ? formatNumber(parseFloat(hop.orderbook.orderbook.ask), 7) : "—"}
+                          {hop.orderbook.orderbook?.ask != null ? formatNumber(parseFloat(hop.orderbook.orderbook.ask), 7) : "—"}
                         </span>
                       </div>
                       <div className="flex justify-between gap-3">
@@ -206,14 +206,14 @@ function formatPriceTooltip(details?: PriceDetails, showOrderbookDetails = true)
                           BID:
                         </span>
                         <span className={`font-mono ${hop.orderbook.bestSource === "orderbook" ? "text-warning-amber" : "text-steel-gray"}`}>
-                          {hop.orderbook.orderbook.bid !== null ? formatNumber(parseFloat(hop.orderbook.orderbook.bid), 7) : "—"}
+                          {hop.orderbook.orderbook?.bid != null ? formatNumber(parseFloat(hop.orderbook.orderbook.bid), 7) : "—"}
                         </span>
                       </div>
                     </div>
                   )}
 
                   {/* AMM prices */}
-                  {(hop.orderbook.amm.ask !== null || hop.orderbook.amm.bid !== null) && (
+                  {(hop.orderbook.amm?.ask != null || hop.orderbook.amm?.bid != null) && (
                     <div className="space-y-0.5 pt-1">
                       <div className="text-steel-gray uppercase text-[9px] font-bold">AMM POOL:</div>
                       <div className="flex justify-between gap-3">
@@ -221,7 +221,7 @@ function formatPriceTooltip(details?: PriceDetails, showOrderbookDetails = true)
                           ASK:
                         </span>
                         <span className={`font-mono ${hop.orderbook.bestSource === "amm" ? "text-cyber-green" : "text-steel-gray"}`}>
-                          {hop.orderbook.amm.ask !== null ? formatNumber(parseFloat(hop.orderbook.amm.ask), 7) : "—"}
+                          {hop.orderbook.amm?.ask != null ? formatNumber(parseFloat(hop.orderbook.amm.ask), 7) : "—"}
                         </span>
                       </div>
                       <div className="flex justify-between gap-3">
@@ -229,10 +229,10 @@ function formatPriceTooltip(details?: PriceDetails, showOrderbookDetails = true)
                           BID:
                         </span>
                         <span className={`font-mono ${hop.orderbook.bestSource === "amm" ? "text-warning-amber" : "text-steel-gray"}`}>
-                          {hop.orderbook.amm.bid !== null ? formatNumber(parseFloat(hop.orderbook.amm.bid), 7) : "—"}
+                          {hop.orderbook.amm?.bid != null ? formatNumber(parseFloat(hop.orderbook.amm.bid), 7) : "—"}
                         </span>
                       </div>
-                      {hop.orderbook.amm.poolId !== null && hop.orderbook.amm.poolId !== undefined && (
+                      {hop.orderbook.amm?.poolId != null && (
                         <div className="text-steel-gray text-[9px] mt-0.5 truncate" title={hop.orderbook.amm.poolId}>
                           Pool: {hop.orderbook.amm.poolId.substring(0, 8)}...
                         </div>

--- a/apps/stat.mtlf.me/src/components/portfolio/portfolio-demo.tsx
+++ b/apps/stat.mtlf.me/src/components/portfolio/portfolio-demo.tsx
@@ -3,7 +3,7 @@
 import { FundStructureLoading } from "@/components/ui/loading-skeleton";
 import { useFundData } from "@/hooks/use-fund-data";
 import { useSnapshots } from "@/hooks/use-snapshots";
-import { API_ENDPOINTS, DEFAULT_ENDPOINT, loadEndpoint, saveEndpoint } from "@/lib/api-endpoints";
+import { API_ENDPOINTS, LOCAL_SENTINEL, loadEndpoint, saveEndpoint } from "@/lib/api-endpoints";
 import { FundStructureTable } from "./fund-structure-table";
 import {
   Select,
@@ -12,19 +12,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 export function PortfolioDemo() {
-  const [baseUrl, setBaseUrl] = useState(DEFAULT_ENDPOINT);
-
-  useEffect(() => {
-    setBaseUrl(loadEndpoint());
-  }, []);
+  const [baseUrl, setBaseUrl] = useState(loadEndpoint);
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
-  const { snapshots, isLoading: snapshotsLoading } = useSnapshots(baseUrl);
+  const { snapshots, isLoading: snapshotsLoading, error: snapshotsError } = useSnapshots(baseUrl);
   const { data: fundData, isLoading, error } = useFundData(selectedDate, baseUrl);
-
-  const LOCAL_SENTINEL = "__local__";
 
   const handleEndpointChange = (value: string) => {
     const url = value === LOCAL_SENTINEL ? "" : value;
@@ -92,12 +86,12 @@ export function PortfolioDemo() {
         </Select>
       </div>
 
-      {error != null && (
+      {(error ?? snapshotsError) != null && (
         <div className="border border-red-500 bg-red-500/10 p-6">
           <h2 className="font-mono text-red-500 uppercase tracking-wider text-xl mb-2">
             ОШИБКА ЗАГРУЗКИ
           </h2>
-          <p className="font-mono text-red-400">{error}</p>
+          <p className="font-mono text-red-400">{error ?? snapshotsError}</p>
         </div>
       )}
 

--- a/apps/stat.mtlf.me/src/components/portfolio/portfolio-demo.tsx
+++ b/apps/stat.mtlf.me/src/components/portfolio/portfolio-demo.tsx
@@ -3,6 +3,7 @@
 import { FundStructureLoading } from "@/components/ui/loading-skeleton";
 import { useFundData } from "@/hooks/use-fund-data";
 import { useSnapshots } from "@/hooks/use-snapshots";
+import { API_ENDPOINTS, DEFAULT_ENDPOINT, loadEndpoint, saveEndpoint } from "@/lib/api-endpoints";
 import { FundStructureTable } from "./fund-structure-table";
 import {
   Select,
@@ -11,46 +12,53 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 export function PortfolioDemo() {
+  const [baseUrl, setBaseUrl] = useState(DEFAULT_ENDPOINT);
+
+  useEffect(() => {
+    setBaseUrl(loadEndpoint());
+  }, []);
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
-  const { snapshots, isLoading: snapshotsLoading } = useSnapshots();
-  const { data: fundData, isLoading, error } = useFundData(selectedDate);
+  const { snapshots, isLoading: snapshotsLoading } = useSnapshots(baseUrl);
+  const { data: fundData, isLoading, error } = useFundData(selectedDate, baseUrl);
 
-  if (error != null) {
-    return (
-      <div className="container mx-auto px-4 py-16">
-        <div className="border border-red-500 bg-red-500/10 p-6">
-          <h2 className="font-mono text-red-500 uppercase tracking-wider text-xl mb-2">
-            ❌ ОШИБКА ЗАГРУЗКИ
-          </h2>
-          <p className="font-mono text-red-400">{error}</p>
-          <button
-            onClick={() => window.location.reload()}
-            className="mt-4 bg-red-500 text-white px-4 py-2 font-mono uppercase tracking-wider hover:bg-red-600 transition-colors"
-          >
-            Обновить страницу
-          </button>
-        </div>
-      </div>
-    );
-  }
+  const LOCAL_SENTINEL = "__local__";
 
-  if (isLoading === true) {
-    return (
-      <div className="container mx-auto px-4 py-16">
-        <FundStructureLoading accountCount={8} />
-      </div>
-    );
-  }
+  const handleEndpointChange = (value: string) => {
+    const url = value === LOCAL_SENTINEL ? "" : value;
+    setBaseUrl(url);
+    saveEndpoint(url);
+    setSelectedDate(null);
+  };
 
   return (
     <div className="container mx-auto px-4 py-16">
-      {/* Snapshot date selector */}
-      <div className="mb-8 flex items-center justify-end gap-4">
+      {/* Endpoint and snapshot selectors */}
+      <div className="mb-8 flex items-center justify-end gap-4 flex-wrap">
         <label className="font-mono text-sm uppercase tracking-wider text-steel-gray">
-          ВЫБРАТЬ SNAPSHOT:
+          ИСТОЧНИК:
+        </label>
+        <Select value={baseUrl || LOCAL_SENTINEL} onValueChange={handleEndpointChange}>
+          <SelectTrigger className="w-[220px] border-electric-cyan bg-background font-mono text-sm uppercase">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent className="border-electric-cyan bg-background">
+            {API_ENDPOINTS.map((ep) => (
+              <SelectItem
+                key={ep.label}
+                value={ep.value || LOCAL_SENTINEL}
+                className="font-mono text-sm uppercase cursor-pointer hover:bg-electric-cyan/20"
+              >
+                {ep.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <label className="font-mono text-sm uppercase tracking-wider text-steel-gray">
+          SNAPSHOT:
         </label>
         <Select
           value={selectedDate ?? "latest"}
@@ -83,6 +91,17 @@ export function PortfolioDemo() {
           </SelectContent>
         </Select>
       </div>
+
+      {error != null && (
+        <div className="border border-red-500 bg-red-500/10 p-6">
+          <h2 className="font-mono text-red-500 uppercase tracking-wider text-xl mb-2">
+            ОШИБКА ЗАГРУЗКИ
+          </h2>
+          <p className="font-mono text-red-400">{error}</p>
+        </div>
+      )}
+
+      {isLoading && <FundStructureLoading accountCount={8} />}
 
       {fundData != null && <FundStructureTable fundData={fundData} isLoading={false} />}
     </div>

--- a/apps/stat.mtlf.me/src/hooks/use-fund-data.ts
+++ b/apps/stat.mtlf.me/src/hooks/use-fund-data.ts
@@ -7,7 +7,7 @@ interface UseFundDataState {
   error: string | null;
 }
 
-export function useFundData(selectedDate?: string | null): UseFundDataState {
+export function useFundData(selectedDate?: string | null, baseUrl = ""): UseFundDataState {
   const [state, setState] = useState<UseFundDataState>({
     data: null,
     isLoading: true,
@@ -22,9 +22,11 @@ export function useFundData(selectedDate?: string | null): UseFundDataState {
         setState({ data: null, isLoading: true, error: null });
 
         // Build URL with optional date parameter
-        const url = selectedDate
-          ? `/api/fund-structure?date=${selectedDate}`
-          : "/api/fund-structure";
+        // Normalize date to YYYY-MM-DD (external APIs may return ISO timestamps)
+        const dateParam = selectedDate?.split("T")[0];
+        const url = dateParam
+          ? `${baseUrl}/api/fund-structure?date=${dateParam}`
+          : `${baseUrl}/api/fund-structure`;
 
         const response = await fetch(url);
 
@@ -53,7 +55,7 @@ export function useFundData(selectedDate?: string | null): UseFundDataState {
     return () => {
       mounted = false;
     };
-  }, [selectedDate]);
+  }, [selectedDate, baseUrl]);
 
   return state;
 }

--- a/apps/stat.mtlf.me/src/hooks/use-snapshots.ts
+++ b/apps/stat.mtlf.me/src/hooks/use-snapshots.ts
@@ -11,7 +11,7 @@ interface UseSnapshotsState {
   error: string | null;
 }
 
-export function useSnapshots(): UseSnapshotsState {
+export function useSnapshots(baseUrl = ""): UseSnapshotsState {
   const [state, setState] = useState<UseSnapshotsState>({
     snapshots: [],
     isLoading: true,
@@ -25,7 +25,7 @@ export function useSnapshots(): UseSnapshotsState {
       try {
         setState({ snapshots: [], isLoading: true, error: null });
 
-        const response = await fetch("/api/snapshots");
+        const response = await fetch(`${baseUrl}/api/snapshots`);
 
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);
@@ -52,7 +52,7 @@ export function useSnapshots(): UseSnapshotsState {
     return () => {
       mounted = false;
     };
-  }, []);
+  }, [baseUrl]);
 
   return state;
 }

--- a/apps/stat.mtlf.me/src/lib/api-endpoints.ts
+++ b/apps/stat.mtlf.me/src/lib/api-endpoints.ts
@@ -1,0 +1,21 @@
+export const API_ENDPOINTS = [
+  { value: "https://stat.mtlprog.xyz", label: "stat.mtlprog.xyz" },
+  { value: "", label: "stat.mtlf.me" },
+] as const;
+
+export const DEFAULT_ENDPOINT = "https://stat.mtlprog.xyz";
+
+const STORAGE_KEY = "stat-mtlf-api-endpoint";
+
+const ALLOWED_VALUES: Set<string> = new Set(API_ENDPOINTS.map((ep) => ep.value));
+
+export function loadEndpoint(): string {
+  if (typeof window === "undefined") return DEFAULT_ENDPOINT;
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored != null && ALLOWED_VALUES.has(stored)) return stored;
+  return DEFAULT_ENDPOINT;
+}
+
+export function saveEndpoint(endpoint: string): void {
+  localStorage.setItem(STORAGE_KEY, endpoint);
+}

--- a/apps/stat.mtlf.me/src/lib/api-endpoints.ts
+++ b/apps/stat.mtlf.me/src/lib/api-endpoints.ts
@@ -5,17 +5,28 @@ export const API_ENDPOINTS = [
 
 export const DEFAULT_ENDPOINT = "https://stat.mtlprog.xyz";
 
+export const LOCAL_SENTINEL = "__local__";
+
 const STORAGE_KEY = "stat-mtlf-api-endpoint";
 
 const ALLOWED_VALUES: Set<string> = new Set(API_ENDPOINTS.map((ep) => ep.value));
 
 export function loadEndpoint(): string {
   if (typeof window === "undefined") return DEFAULT_ENDPOINT;
-  const stored = localStorage.getItem(STORAGE_KEY);
-  if (stored != null && ALLOWED_VALUES.has(stored)) return stored;
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored != null && ALLOWED_VALUES.has(stored)) return stored;
+  } catch {
+    // localStorage inaccessible (private browsing, iframe restrictions)
+  }
   return DEFAULT_ENDPOINT;
 }
 
 export function saveEndpoint(endpoint: string): void {
-  localStorage.setItem(STORAGE_KEY, endpoint);
+  if (!ALLOWED_VALUES.has(endpoint)) return;
+  try {
+    localStorage.setItem(STORAGE_KEY, endpoint);
+  } catch {
+    // localStorage inaccessible
+  }
 }

--- a/packages/utils/src/format.test.ts
+++ b/packages/utils/src/format.test.ts
@@ -49,4 +49,20 @@ describe("formatNumber", () => {
     expect(result).not.toContain(" "); // Regular space
     expect(result).not.toContain(","); // Comma separator
   });
+
+  test("should handle string values", () => {
+    expect(formatNumber("1234567.89", 2)).toBe("1\u202F234\u202F567.89");
+    expect(formatNumber("1234.5678", 7)).toBe("1\u202F234.5678000");
+    expect(formatNumber("0", 2)).toBe("0.00");
+  });
+
+  test("should handle non-numeric strings as zero", () => {
+    expect(formatNumber("not-a-number", 2)).toBe("0.00");
+    expect(formatNumber("", 2)).toBe("0.00");
+  });
+
+  test("should handle null and undefined", () => {
+    expect(formatNumber(null, 2)).toBe("0.00");
+    expect(formatNumber(undefined, 2)).toBe("0.00");
+  });
 });

--- a/packages/utils/src/format.ts
+++ b/packages/utils/src/format.ts
@@ -10,8 +10,8 @@
  * formatNumber(1234567.89, 2) // "1 234 567.89"
  * formatNumber(1234.5678, 7)  // "1 234.5678000"
  */
-export function formatNumber(value: number | null | undefined, decimals: number = 2): string {
-  const safeValue = value ?? 0;
+export function formatNumber(value: number | string | null | undefined, decimals: number = 2): string {
+  const safeValue = Number(value ?? 0) || 0;
   const fixed = safeValue.toFixed(decimals);
   const parts = fixed.split(".");
   const integerPart = parts[0];


### PR DESCRIPTION
## Summary

- Add dropdown selector to switch between `stat.mtlprog.xyz` (default) and `stat.mtlf.me` API endpoints
- Persist selected endpoint in localStorage across page reloads
- Fix external API data compatibility: string-typed numbers, missing optional fields, ISO date normalization

## Test plan

- [ ] Verify CORS headers are set on `stat.mtlprog.xyz` (`Access-Control-Allow-Origin: https://stat.mtlf.me`)
- [ ] Test switching between both endpoints — data loads correctly for each
- [ ] Test historical snapshot selection works with both endpoints
- [ ] Test persistence: reload page after switching endpoint, verify it remembers
- [ ] Test error state: selectors remain visible and functional during errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)