### PR TITLE
feat(stat.mtlf.me): add blockchain explorer selector

### DIFF
--- a/apps/stat.mtlf.me/src/components/portfolio/fund-structure-table.tsx
+++ b/apps/stat.mtlf.me/src/components/portfolio/fund-structure-table.tsx
@@ -5,6 +5,7 @@ import { StellarAccount } from "@/components/ui/stellar-account";
 import { StellarAsset } from "@/components/ui/stellar-asset";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import type { BlockchainExplorer } from "@/lib/blockchain-explorer";
 import type { FundAccountPortfolio, FundStructureData } from "@/lib/stellar/fund-structure-service";
 import type { PriceDetails } from "@/lib/stellar/types";
 import { formatNumber } from "@/lib/utils";
@@ -14,6 +15,7 @@ import { FundSummaryMetrics } from "./fund-summary-metrics";
 
 interface FundStructureTableProps {
   fundData: FundStructureData;
+  explorer: BlockchainExplorer;
   isLoading?: boolean;
 }
 
@@ -280,7 +282,7 @@ function AccountTypeIndicator({ type }: { type: "issuer" | "subfond" | "mutual" 
   );
 }
 
-function AccountSection({ account, hideIlliquidTokens }: { account: FundAccountPortfolio; hideIlliquidTokens: boolean }) {
+function AccountSection({ account, hideIlliquidTokens, explorer }: { account: FundAccountPortfolio; hideIlliquidTokens: boolean; explorer: BlockchainExplorer }) {
   // Filter tokens based on hideIlliquidTokens setting
   const filteredTokens = hideIlliquidTokens
     ? account.tokens.filter((token) => token.valueInEURMTL !== null && token.valueInEURMTL !== undefined)
@@ -301,7 +303,7 @@ function AccountSection({ account, hideIlliquidTokens }: { account: FundAccountP
             <p className="text-sm font-mono text-steel-gray mt-1">
               {account.description}
             </p>
-            <StellarAccount accountId={account.id} className="mt-1" />
+            <StellarAccount accountId={account.id} explorer={explorer} className="mt-1" />
           </div>
           <div className="text-right">
             <div className="text-sm font-mono text-steel-gray uppercase">ИТОГО СЧЁТА</div>
@@ -321,7 +323,7 @@ function AccountSection({ account, hideIlliquidTokens }: { account: FundAccountP
           <TableBody>
             <TableRow className="border-border">
               <TableCell className="w-32">
-                <StellarAsset assetCode="XLM" />
+                <StellarAsset assetCode="XLM" explorer={explorer} />
               </TableCell>
               <TableCell className="font-mono text-foreground w-40">
                 {formatNumber(parseFloat(account.xlmBalance), 7)}
@@ -349,6 +351,7 @@ function AccountSection({ account, hideIlliquidTokens }: { account: FundAccountP
                   <StellarAsset
                     assetCode={token.asset.code}
                     assetIssuer={token.asset.issuer}
+                    explorer={explorer}
                   />
                 </TableCell>
                 <TableCell className="font-mono text-foreground">
@@ -593,7 +596,7 @@ function AccountSection({ account, hideIlliquidTokens }: { account: FundAccountP
   );
 }
 
-export function FundStructureTable({ fundData, isLoading = false }: FundStructureTableProps) {
+export function FundStructureTable({ fundData, explorer, isLoading = false }: FundStructureTableProps) {
   const [hideIlliquidTokens, setHideIlliquidTokens] = React.useState(false);
 
   if (isLoading) {
@@ -713,7 +716,7 @@ export function FundStructureTable({ fundData, isLoading = false }: FundStructur
             {/* Account Sections */}
             <div className="space-y-6">
               {fundData.accounts.map((account, index) => (
-                <AccountSection key={index} account={account} hideIlliquidTokens={hideIlliquidTokens} />
+                <AccountSection key={index} account={account} hideIlliquidTokens={hideIlliquidTokens} explorer={explorer} />
               ))}
             </div>
           </div>
@@ -837,7 +840,7 @@ export function FundStructureTable({ fundData, isLoading = false }: FundStructur
               {/* Other Account Sections */}
               <div className="space-y-6">
                 {fundData.otherAccounts.map((account, index) => (
-                  <AccountSection key={index} account={account} hideIlliquidTokens={hideIlliquidTokens} />
+                  <AccountSection key={index} account={account} hideIlliquidTokens={hideIlliquidTokens} explorer={explorer} />
                 ))}
               </div>
             </div>

--- a/apps/stat.mtlf.me/src/components/portfolio/portfolio-client.tsx
+++ b/apps/stat.mtlf.me/src/components/portfolio/portfolio-client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { BlockchainExplorer } from "@/lib/blockchain-explorer";
 import type { TokenPriceWithBalance } from "@/lib/stellar/price-service";
 import { handleStateError } from "@/lib/utils/error-handling";
 import * as S from "@effect/schema/Schema";
@@ -26,9 +27,10 @@ interface PortfolioData {
 
 interface PortfolioClientProps {
   initialData?: PortfolioData;
+  explorer: BlockchainExplorer;
 }
 
-export function PortfolioClient({ initialData }: PortfolioClientProps) {
+export function PortfolioClient({ initialData, explorer }: PortfolioClientProps) {
   const [data, setData] = useState<PortfolioData | null>(initialData ?? null);
   const [loading, setLoading] = useState(initialData == null);
   const [error, setError] = useState<string | null>(null);
@@ -109,6 +111,7 @@ export function PortfolioClient({ initialData }: PortfolioClientProps) {
           accountId="GACKTN5DAZGWXRWB2WLM6OPBDHAMT6SJNGLJZPQMEZBUR4JUGBX2UK7V"
           tokens={[]}
           xlmBalance="0"
+          explorer={explorer}
           isLoading={true}
         />
       </div>
@@ -131,6 +134,7 @@ export function PortfolioClient({ initialData }: PortfolioClientProps) {
         accountId={data.accountId}
         tokens={data.tokens}
         xlmBalance={data.xlmBalance}
+        explorer={explorer}
         xlmPriceInEURMTL={data.xlmPriceInEURMTL}
         isLoading={false}
       />

--- a/apps/stat.mtlf.me/src/components/portfolio/portfolio-demo.tsx
+++ b/apps/stat.mtlf.me/src/components/portfolio/portfolio-demo.tsx
@@ -4,6 +4,7 @@ import { FundStructureLoading } from "@/components/ui/loading-skeleton";
 import { useFundData } from "@/hooks/use-fund-data";
 import { useSnapshots } from "@/hooks/use-snapshots";
 import { API_ENDPOINTS, LOCAL_SENTINEL, loadEndpoint, saveEndpoint } from "@/lib/api-endpoints";
+import { EXPLORERS, loadExplorer, saveExplorer } from "@/lib/blockchain-explorer";
 import { FundStructureTable } from "./fund-structure-table";
 import {
   Select,
@@ -17,6 +18,7 @@ import { useState } from "react";
 export function PortfolioDemo() {
   const [baseUrl, setBaseUrl] = useState(loadEndpoint);
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
+  const [explorer, setExplorer] = useState(loadExplorer);
   const { snapshots, isLoading: snapshotsLoading, error: snapshotsError } = useSnapshots(baseUrl);
   const { data: fundData, isLoading, error } = useFundData(selectedDate, baseUrl);
 
@@ -27,15 +29,22 @@ export function PortfolioDemo() {
     setSelectedDate(null);
   };
 
+  const handleExplorerChange = (explorerId: string) => {
+    const selected = EXPLORERS.find((e) => e.id === explorerId);
+    if (selected === undefined) return;
+    setExplorer(selected);
+    saveExplorer(explorerId);
+  };
+
   return (
     <div className="container mx-auto px-4 py-16">
-      {/* Endpoint and snapshot selectors */}
-      <div className="mb-8 flex items-center justify-end gap-4 flex-wrap">
-        <label className="font-mono text-sm uppercase tracking-wider text-steel-gray">
-          ИСТОЧНИК:
+      {/* Endpoint, explorer, and snapshot selectors */}
+      <div className="mb-8 grid grid-cols-[auto_1fr] sm:grid-cols-[auto_auto_auto_auto_auto_auto] items-center gap-x-4 gap-y-3 sm:justify-end">
+        <label className="font-mono text-sm uppercase tracking-wider text-steel-gray whitespace-nowrap">
+          SOURCE:
         </label>
         <Select value={baseUrl || LOCAL_SENTINEL} onValueChange={handleEndpointChange}>
-          <SelectTrigger className="w-[220px] border-electric-cyan bg-background font-mono text-sm uppercase">
+          <SelectTrigger className="w-full sm:w-[200px] border-electric-cyan bg-background font-mono text-sm uppercase">
             <SelectValue />
           </SelectTrigger>
           <SelectContent className="border-electric-cyan bg-background">
@@ -51,7 +60,27 @@ export function PortfolioDemo() {
           </SelectContent>
         </Select>
 
-        <label className="font-mono text-sm uppercase tracking-wider text-steel-gray">
+        <label className="font-mono text-sm uppercase tracking-wider text-steel-gray whitespace-nowrap">
+          EXPLORER:
+        </label>
+        <Select value={explorer.id} onValueChange={handleExplorerChange}>
+          <SelectTrigger className="w-full sm:w-[200px] border-electric-cyan bg-background font-mono text-sm uppercase">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent className="border-electric-cyan bg-background">
+            {EXPLORERS.map((e) => (
+              <SelectItem
+                key={e.id}
+                value={e.id}
+                className="font-mono text-sm uppercase cursor-pointer hover:bg-electric-cyan/20"
+              >
+                {e.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <label className="font-mono text-sm uppercase tracking-wider text-steel-gray whitespace-nowrap">
           SNAPSHOT:
         </label>
         <Select
@@ -59,15 +88,15 @@ export function PortfolioDemo() {
           onValueChange={(value) => setSelectedDate(value === "latest" ? null : value)}
           disabled={snapshotsLoading}
         >
-          <SelectTrigger className="w-[280px] border-electric-cyan bg-background font-mono text-sm uppercase">
-            <SelectValue placeholder="ЗАГРУЗКА..." />
+          <SelectTrigger className="w-full sm:w-[260px] border-electric-cyan bg-background font-mono text-sm uppercase">
+            <SelectValue placeholder="LOADING..." />
           </SelectTrigger>
           <SelectContent className="max-h-[400px] border-electric-cyan bg-background">
             <SelectItem
               value="latest"
               className="font-mono text-sm uppercase cursor-pointer hover:bg-electric-cyan/20"
             >
-              ↗ ПОСЛЕДНИЙ SNAPSHOT
+              LATEST SNAPSHOT
             </SelectItem>
             {snapshots.map((snapshot) => (
               <SelectItem
@@ -97,7 +126,7 @@ export function PortfolioDemo() {
 
       {isLoading && <FundStructureLoading accountCount={8} />}
 
-      {fundData != null && <FundStructureTable fundData={fundData} isLoading={false} />}
+      {fundData != null && <FundStructureTable fundData={fundData} explorer={explorer} isLoading={false} />}
     </div>
   );
 }

--- a/apps/stat.mtlf.me/src/components/portfolio/portfolio-table.tsx
+++ b/apps/stat.mtlf.me/src/components/portfolio/portfolio-table.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 import { Card } from "@/components/ui/card";
+import { StellarAccount } from "@/components/ui/stellar-account";
+import { StellarAsset } from "@/components/ui/stellar-asset";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import type { BlockchainExplorer } from "@/lib/blockchain-explorer";
 import type { TokenPriceWithBalance } from "@/lib/stellar/price-service";
 import type { PriceDetails } from "@/lib/stellar/types";
 import { formatNumber } from "@/lib/utils";
@@ -13,16 +16,8 @@ interface PortfolioTableProps {
   tokens: readonly TokenPriceWithBalance[];
   xlmBalance: string;
   xlmPriceInEURMTL?: string | undefined;
+  explorer: BlockchainExplorer;
   isLoading?: boolean;
-}
-
-function formatTokenName(code: string): string {
-  if (code === "XLM") return "XLM";
-  return `${code}`;
-}
-
-function formatAddress(address: string): string {
-  return `${address.slice(0, 6)}...${address.slice(-4)}`;
 }
 
 function formatPriceTooltip(details?: PriceDetails): React.ReactNode {
@@ -61,6 +56,7 @@ export function PortfolioTable({
   tokens,
   xlmBalance,
   xlmPriceInEURMTL,
+  explorer,
   isLoading = false,
 }: PortfolioTableProps) {
   // Filter out tokens that have no price in both XLM and EURMTL (illiquid service tokens)
@@ -98,7 +94,10 @@ export function PortfolioTable({
         <Card className="p-0 border-0 bg-black text-white overflow-hidden">
           <div className="bg-cyber-green text-black p-6">
             <h2 className="text-3xl font-mono uppercase tracking-wider">ПОРТФЕЛЬ</h2>
-            <p className="text-lg font-mono mt-2">СЧЕТ: {formatAddress(accountId)}</p>
+            <div className="text-lg font-mono mt-2 flex items-center gap-2">
+              <span>СЧЕТ:</span>
+              <StellarAccount accountId={accountId} explorer={explorer} className="[&_button]:text-background [&_button]:hover:text-steel-gray" />
+            </div>
           </div>
 
           <div className="p-6">
@@ -122,7 +121,9 @@ export function PortfolioTable({
               <TableBody>
                 {/* XLM Balance */}
                 <TableRow className="border-steel-gray hover:bg-steel-gray/10">
-                  <TableCell className="font-mono text-cyber-green">XLM</TableCell>
+                  <TableCell>
+                    <StellarAsset assetCode="XLM" explorer={explorer} />
+                  </TableCell>
                   <TableCell className="font-mono text-white">{formatNumber(parseFloat(xlmBalance), 7)}</TableCell>
                   <TableCell className="text-right font-mono text-white">
                     {xlmPriceInEURMTL != null && xlmPriceInEURMTL !== ""
@@ -143,8 +144,8 @@ export function PortfolioTable({
                 {/* Other Tokens */}
                 {liquidTokens.map((token, index) => (
                   <TableRow key={index} className="border-steel-gray hover:bg-steel-gray/10">
-                    <TableCell className="font-mono text-cyber-green">
-                      {formatTokenName(token.asset.code)}
+                    <TableCell>
+                      <StellarAsset assetCode={token.asset.code} assetIssuer={token.asset.issuer} explorer={explorer} />
                     </TableCell>
                     <TableCell className="font-mono text-white">
                       {formatNumber(parseFloat(token.balance), token.asset.code === "EURMTL" ? 2 : 7)}

--- a/apps/stat.mtlf.me/src/components/ui/stellar-account.tsx
+++ b/apps/stat.mtlf.me/src/components/ui/stellar-account.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import * as S from "@effect/schema/Schema";
-import { Effect, pipe } from "effect";
+import { Effect, Option, pipe } from "effect";
 import { Copy, ExternalLink } from "lucide-react";
 import { useState } from "react";
+import type { BlockchainExplorer } from "@/lib/blockchain-explorer";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./tooltip";
 
 // Error definitions
@@ -17,11 +18,12 @@ export class ClipboardError extends S.TaggedError<ClipboardError>()(
 
 interface StellarAccountProps {
   accountId: string;
+  explorer: BlockchainExplorer;
   className?: string;
   showIcon?: boolean;
 }
 
-export function StellarAccount({ accountId, className = "", showIcon = true }: StellarAccountProps) {
+export function StellarAccount({ accountId, explorer, className = "", showIcon = true }: StellarAccountProps) {
   const [copied, setCopied] = useState(false);
 
   const formatAddress = (address: string): string => {
@@ -58,26 +60,34 @@ export function StellarAccount({ accountId, className = "", showIcon = true }: S
     });
   };
 
-  const openInStellarExpert = () => {
-    const program = pipe(
-      Effect.sync(() => window.open(`https://stellar.expert/explorer/public/account/${accountId}`, "_blank")),
-      Effect.tap(() => Effect.log(`Opened Stellar Expert for account: ${accountId}`)),
-    );
+  const url = explorer.accountUrl(accountId);
 
-    Effect.runSync(program);
+  const openInExplorer = () => {
+    Option.match(url, {
+      onNone: () => {},
+      onSome: (href) => window.open(href, "_blank"),
+    });
   };
+
+  const addressElement = Option.isSome(url) ? (
+    <button
+      onClick={openInExplorer}
+      className="font-mono text-steel-gray hover:text-cyber-green transition-colors cursor-pointer"
+    >
+      {formatAddress(accountId)}
+      {showIcon && <ExternalLink className="w-3 h-3 inline ml-1" />}
+    </button>
+  ) : (
+    <span className="font-mono text-steel-gray">
+      {formatAddress(accountId)}
+    </span>
+  );
 
   return (
     <div className={`flex items-center gap-2 ${className}`}>
       <Tooltip>
         <TooltipTrigger asChild>
-          <button
-            onClick={openInStellarExpert}
-            className="font-mono text-steel-gray hover:text-cyber-green transition-colors cursor-pointer"
-          >
-            {formatAddress(accountId)}
-            {showIcon && <ExternalLink className="w-3 h-3 inline ml-1" />}
-          </button>
+          {addressElement}
         </TooltipTrigger>
         <TooltipContent side="top" className="max-w-xs">
           <div className="font-mono space-y-2">
@@ -98,7 +108,7 @@ export function StellarAccount({ accountId, className = "", showIcon = true }: S
         </TooltipTrigger>
         <TooltipContent side="top">
           <div className="font-mono text-xs">
-            {copied ? "✅ COPIED!" : "Copy account ID"}
+            {copied ? "COPIED" : "Copy account ID"}
           </div>
         </TooltipContent>
       </Tooltip>

--- a/apps/stat.mtlf.me/src/components/ui/stellar-asset.tsx
+++ b/apps/stat.mtlf.me/src/components/ui/stellar-asset.tsx
@@ -1,31 +1,43 @@
 "use client";
 
+import type { BlockchainExplorer } from "@/lib/blockchain-explorer";
+import { Option } from "effect";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./tooltip";
 
 interface StellarAssetProps {
   assetCode: string;
   assetIssuer?: string;
+  explorer: BlockchainExplorer;
   className?: string;
 }
 
-export function StellarAsset({ assetCode, assetIssuer, className = "" }: StellarAssetProps) {
-  const openInStellarExpert = () => {
-    if (assetCode === "XLM" || assetIssuer === undefined || assetIssuer === null || assetIssuer === "") {
-      window.open("https://stellar.expert/explorer/public/asset/XLM", "_blank");
-    } else {
-      window.open(`https://stellar.expert/explorer/public/asset/${assetCode}-${assetIssuer}`, "_blank");
-    }
+export function StellarAsset({ assetCode, assetIssuer, explorer, className = "" }: StellarAssetProps) {
+  const url = explorer.assetUrl(assetCode, assetIssuer);
+
+  const openInExplorer = () => {
+    Option.match(url, {
+      onNone: () => {},
+      onSome: (href) => window.open(href, "_blank"),
+    });
   };
+
+  const codeElement = Option.isSome(url) ? (
+    <button
+      onClick={openInExplorer}
+      className={`font-mono text-cyber-green hover:text-white transition-colors cursor-pointer ${className}`}
+    >
+      {assetCode}
+    </button>
+  ) : (
+    <span className={`font-mono text-cyber-green ${className}`}>
+      {assetCode}
+    </span>
+  );
 
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <button
-          onClick={openInStellarExpert}
-          className={`font-mono text-cyber-green hover:text-white transition-colors cursor-pointer ${className}`}
-        >
-          {assetCode}
-        </button>
+        {codeElement}
       </TooltipTrigger>
       <TooltipContent side="top" className="max-w-xs">
         <div className="font-mono space-y-2">

--- a/apps/stat.mtlf.me/src/lib/blockchain-explorer.ts
+++ b/apps/stat.mtlf.me/src/lib/blockchain-explorer.ts
@@ -1,0 +1,59 @@
+import { Option } from "effect";
+
+export interface BlockchainExplorer {
+  readonly id: string;
+  readonly label: string;
+  readonly accountUrl: (accountId: string) => Option.Option<string>;
+  readonly assetUrl: (assetCode: string, assetIssuer?: string) => Option.Option<string>;
+}
+
+export const STELLAR_EXPERT: BlockchainExplorer = {
+  id: "stellar-expert",
+  label: "stellar.expert",
+  accountUrl: (accountId) =>
+    Option.some(`https://stellar.expert/explorer/public/account/${accountId}`),
+  assetUrl: (assetCode, assetIssuer?) =>
+    assetCode === "XLM" || assetIssuer === undefined || assetIssuer === ""
+      ? Option.some("https://stellar.expert/explorer/public/asset/XLM")
+      : Option.some(`https://stellar.expert/explorer/public/asset/${assetCode}-${assetIssuer}`),
+};
+
+export const LORE_MTLPROG: BlockchainExplorer = {
+  id: "lore",
+  label: "lore.mtlprog.xyz",
+  accountUrl: (accountId) =>
+    Option.some(`https://lore.mtlprog.xyz/accounts/${accountId}`),
+  assetUrl: (assetCode, assetIssuer?) =>
+    assetCode === "XLM" || assetIssuer === undefined || assetIssuer === ""
+      ? Option.none()
+      : Option.some(`https://lore.mtlprog.xyz/tokens/${assetIssuer}/${assetCode}`),
+};
+
+export const EXPLORERS: readonly BlockchainExplorer[] = [LORE_MTLPROG, STELLAR_EXPERT];
+
+const STORAGE_KEY = "stat-mtlf-blockchain-explorer";
+
+const EXPLORER_MAP = new Map(EXPLORERS.map((e) => [e.id, e]));
+
+export function loadExplorer(): BlockchainExplorer {
+  if (typeof window === "undefined") return LORE_MTLPROG;
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored != null) {
+      const found = EXPLORER_MAP.get(stored);
+      if (found !== undefined) return found;
+    }
+  } catch {
+    // localStorage inaccessible
+  }
+  return LORE_MTLPROG;
+}
+
+export function saveExplorer(explorerId: string): void {
+  if (!EXPLORER_MAP.has(explorerId)) return;
+  try {
+    localStorage.setItem(STORAGE_KEY, explorerId);
+  } catch {
+    // localStorage inaccessible
+  }
+}


### PR DESCRIPTION
## Summary

- Add configurable blockchain explorer selector (lore.mtlprog.xyz default, stellar.expert alternative) with localStorage persistence
- Use Effect-TS `Option` pattern for URL generation — gracefully renders plain text when an explorer doesn't support a link type (e.g. XLM on lore.mtlprog.xyz)
- Update `StellarAccount`, `StellarAsset`, `FundStructureTable`, `PortfolioTable`, and `PortfolioClient` to accept and thread the explorer prop
- Responsive grid layout for toolbar selectors; labels switched to English (SOURCE, EXPLORER, SNAPSHOT)

## Test plan

- [ ] Verify lore.mtlprog.xyz is selected by default on fresh load (no localStorage)
- [ ] Switch to stellar.expert — all account/asset links should open on stellar.expert
- [ ] Switch back to lore.mtlprog.xyz — XLM should render as plain text (no link), other assets should open on lore
- [ ] Reload the page — explorer choice should persist from localStorage
- [ ] Test on mobile viewport — selectors should stack vertically with full-width triggers
- [ ] Verify `bun run build` succeeds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)