### PR TITLE
feat(stat.mtlf.me): indicator search/views, pie totals, English UI

### DIFF
--- a/apps/stat.mtlf.me/app/fund/page.tsx
+++ b/apps/stat.mtlf.me/app/fund/page.tsx
@@ -11,13 +11,6 @@ export default function FundPage() {
         <div className="container mx-auto">
           <div className="flex flex-wrap items-start justify-between gap-4">
             <div>
-              <Link
-                href="/"
-                className="inline-flex items-center gap-2 font-mono text-xs uppercase tracking-widest text-electric-cyan hover:text-cyber-green transition-colors mb-3"
-              >
-                <ArrowLeft className="h-3 w-3" />
-                DASHBOARD
-              </Link>
               <h1 className="text-5xl font-mono uppercase tracking-wider text-cyber-green mb-2">
                 MTLF.FUND
               </h1>
@@ -25,10 +18,20 @@ export default function FundPage() {
                 FUND STRUCTURE // ACCOUNTS // TOKENS
               </p>
             </div>
-            <div className="mt-2">
-              <ModeToggle />
-            </div>
+            <ModeToggle />
           </div>
+        </div>
+      </div>
+
+      <div className="border-b border-border bg-background">
+        <div className="container mx-auto px-6 py-3">
+          <Link
+            href="/"
+            className="inline-flex items-center gap-2 font-mono text-xs uppercase tracking-widest text-electric-cyan hover:text-cyber-green transition-colors"
+          >
+            <ArrowLeft className="h-3 w-3" />
+            BACK TO DASHBOARD
+          </Link>
         </div>
       </div>
 

--- a/apps/stat.mtlf.me/app/page.tsx
+++ b/apps/stat.mtlf.me/app/page.tsx
@@ -1,8 +1,6 @@
 import { DashboardPage } from "@/components/dashboard/dashboard-page";
 import { Footer } from "@/components/layout/footer";
 import { ModeToggle } from "@/components/ui/mode-toggle";
-import { ArrowRight } from "lucide-react";
-import Link from "next/link";
 
 export default function Home() {
   return (
@@ -18,16 +16,7 @@ export default function Home() {
                 MONTELIBERO FOUNDATION // PORTFOLIO STATISTICS
               </p>
             </div>
-            <div className="flex items-center gap-3">
-              <Link
-                href="/fund"
-                className="inline-flex items-center gap-2 border border-cyber-green bg-background px-4 py-2 font-mono text-sm uppercase tracking-wider text-cyber-green hover:bg-cyber-green hover:text-background transition-colors"
-              >
-                FUND DETAILS
-                <ArrowRight className="h-4 w-4" />
-              </Link>
-              <ModeToggle />
-            </div>
+            <ModeToggle />
           </div>
         </div>
       </div>

--- a/apps/stat.mtlf.me/src/cli/commands/portfolio.ts
+++ b/apps/stat.mtlf.me/src/cli/commands/portfolio.ts
@@ -10,28 +10,28 @@ export const getPortfolioCommand = (
     Effect.gen(function*() {
       const portfolioService = yield* PortfolioServiceTag;
 
-      yield* Effect.log(chalk.cyan("\n🔍 Загружаю портфель...\n"));
-      yield* Effect.log(chalk.gray(`Счет: ${accountId}`));
+      yield* Effect.log(chalk.cyan("\n🔍 Loading portfolio...\n"));
+      yield* Effect.log(chalk.gray(`Account: ${accountId}`));
       yield* Effect.log(chalk.gray("-".repeat(60)));
 
       const portfolio = yield* portfolioService.getAccountPortfolio(accountId);
 
-      yield* Effect.log(chalk.green("✅ Портфель загружен!"));
+      yield* Effect.log(chalk.green("✅ Portfolio loaded!"));
       yield* Effect.log(chalk.bold(`\n💰 XLM: ${portfolio.xlmBalance}`));
 
       if (portfolio.tokens.length > 0) {
-        yield* Effect.log(chalk.bold(`\n📊 Токены (${portfolio.tokens.length}):`));
+        yield* Effect.log(chalk.bold(`\n📊 Tokens (${portfolio.tokens.length}):`));
         for (const token of portfolio.tokens) {
           yield* Effect.log(chalk.white(`  ${token.asset.code}: ${token.balance}`));
           yield* Effect.log(chalk.dim(`    Issuer: ${token.asset.issuer}`));
         }
       } else {
-        yield* Effect.log(chalk.dim("\nНет других токенов"));
+        yield* Effect.log(chalk.dim("\nNo other tokens"));
       }
     }),
     Effect.catchAll((error) =>
       pipe(
-        Effect.logError(chalk.red("\n❌ Ошибка загрузки портфеля:")),
+        Effect.logError(chalk.red("\n❌ Failed to load portfolio:")),
         Effect.tap(() => logErrorWithCause(chalk.red("Error"))(error)),
       )
     ),

--- a/apps/stat.mtlf.me/src/components/dashboard/dashboard-page.tsx
+++ b/apps/stat.mtlf.me/src/components/dashboard/dashboard-page.tsx
@@ -19,6 +19,7 @@ const KEY_INDICATORS: readonly { id: number; name: string }[] = [
 ];
 
 const KEY_IDS = KEY_INDICATORS.map((k) => k.id);
+const TOTAL_INDICATOR_ID = 3;
 
 export function DashboardPage() {
   const { data: subfundData, isLoading: subfundLoading, error: subfundError } = useSubfundBalance();
@@ -27,27 +28,34 @@ export function DashboardPage() {
   const { series, isLoading: historyLoading, error: historyError } = useIndicatorHistory(KEY_IDS, range);
 
   const seriesById = new Map(series.map((s) => [s.id, s]));
+  const totalIndicator = indicators.find((i) => i.id === TOTAL_INDICATOR_ID);
 
   return (
     <div className="container mx-auto space-y-8 px-4 py-8">
       <section>
         {subfundError !== null && (
           <div className="border border-red-500 bg-red-500/10 p-6 font-mono text-sm text-red-400">
-            ОШИБКА ЗАГРУЗКИ САБФОНДОВ: {subfundError}
+            SUBFUND LOAD ERROR: {subfundError}
           </div>
         )}
         {subfundError === null && subfundLoading && (
           <div className="h-[480px] border border-cyber-green/30 bg-steel-gray/10 animate-pulse" />
         )}
         {subfundError === null && !subfundLoading && subfundData !== null && (
-          <SubfundPieChart slices={subfundData.slices} date={subfundData.date} />
+          <SubfundPieChart
+            slices={subfundData.slices}
+            date={subfundData.date}
+            {...(totalIndicator !== undefined
+              ? { totalValue: totalIndicator.value, totalUnit: totalIndicator.unit }
+              : {})}
+          />
         )}
       </section>
 
       <section>
         <div className="mb-4 flex flex-wrap items-baseline justify-between gap-3">
           <h2 className="font-mono text-xl uppercase tracking-wider text-cyber-green">
-            ДИНАМИКА КЛЮЧЕВЫХ ПОКАЗАТЕЛЕЙ
+            KEY METRICS HISTORY
           </h2>
           <RangeSelector value={range} onChange={setRange} />
         </div>

--- a/apps/stat.mtlf.me/src/components/dashboard/indicator-card.test.tsx
+++ b/apps/stat.mtlf.me/src/components/dashboard/indicator-card.test.tsx
@@ -1,7 +1,7 @@
 import type { DecimalString, Indicator } from "@/lib/api/types";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, test } from "bun:test";
-import { IndicatorCard } from "./indicator-card";
+import { IndicatorCard, IndicatorRow } from "./indicator-card";
 
 afterEach(cleanup);
 
@@ -57,5 +57,59 @@ describe("IndicatorCard", () => {
   test("does not render changes block when changes prop missing", () => {
     render(<IndicatorCard indicator={indicator()} />);
     expect(screen.queryByText(/%$/)).toBeNull();
+  });
+});
+
+describe("IndicatorRow", () => {
+  test("renders id, name, and unit", () => {
+    render(<IndicatorRow indicator={indicator()} />);
+    expect(screen.getByText("I3")).toBeDefined();
+    expect(screen.getByText("Assets Value")).toBeDefined();
+    expect(screen.getByText("EURMTL")).toBeDefined();
+  });
+
+  test("renders positive change with cyber-green color", () => {
+    render(
+      <IndicatorRow
+        indicator={indicator({ changes: { "30d": { abs: dec("100"), pct: dec("3.07") } } })}
+      />,
+    );
+    const pct = screen.getByText("+3.07%");
+    expect(pct.className).toContain("text-cyber-green");
+  });
+
+  test("renders negative change with red color", () => {
+    render(
+      <IndicatorRow
+        indicator={indicator({ changes: { "30d": { abs: dec("-50"), pct: dec("-1.50") } } })}
+      />,
+    );
+    const pct = screen.getByText("-1.50%");
+    expect(pct.className).toContain("text-red-400");
+  });
+
+  test("renders em-dash for missing periods", () => {
+    render(
+      <IndicatorRow
+        indicator={indicator({ changes: { "30d": { abs: dec("0"), pct: dec("0") } } })}
+      />,
+    );
+    expect(screen.getAllByText("—").length).toBe(2);
+  });
+
+  test("title attribute falls back to name when description is empty", () => {
+    const { container } = render(
+      <IndicatorRow indicator={indicator({ description: "" })} />,
+    );
+    const titled = container.querySelector('[title="Assets Value"]');
+    expect(titled).not.toBeNull();
+  });
+
+  test("title attribute uses description when present", () => {
+    const { container } = render(
+      <IndicatorRow indicator={indicator({ description: "Total fund assets" })} />,
+    );
+    const titled = container.querySelector('[title="Total fund assets"]');
+    expect(titled).not.toBeNull();
   });
 });

--- a/apps/stat.mtlf.me/src/components/dashboard/indicator-card.tsx
+++ b/apps/stat.mtlf.me/src/components/dashboard/indicator-card.tsx
@@ -84,3 +84,39 @@ export function IndicatorCard({ indicator }: IndicatorCardProps) {
     </div>
   );
 }
+
+export function IndicatorRow({ indicator }: IndicatorCardProps) {
+  const valueNum = toNum(indicator.value);
+  const decimals = indicator.unit === "%" ? 2 : valueNum >= 1000 ? 0 : 4;
+
+  return (
+    <div className="grid grid-cols-[3rem_1fr_auto_auto] items-center gap-3 border border-steel-gray/40 bg-card px-3 py-2 hover:border-electric-cyan transition-colors">
+      <span className="font-mono text-[10px] uppercase tracking-widest text-steel-gray">
+        I{indicator.id}
+      </span>
+      <span
+        className="font-mono text-xs uppercase tracking-wider text-foreground truncate"
+        title={indicator.description !== "" ? indicator.description : indicator.name}
+      >
+        {indicator.name}
+      </span>
+      <span className="font-mono text-sm tabular-nums whitespace-nowrap">
+        <span className="text-cyber-green">{formatNumber(valueNum, decimals)}</span>
+        <span className="ml-1 text-[10px] uppercase text-steel-gray">{indicator.unit}</span>
+      </span>
+      <span className="hidden sm:flex items-center gap-3 font-mono text-[11px] tabular-nums whitespace-nowrap">
+        {PERIODS.map((p) => {
+          const change = indicator.changes?.[p];
+          return (
+            <span key={p} className="flex items-baseline gap-1">
+              <span className="uppercase tracking-wider text-steel-gray">{PERIOD_LABEL[p]}</span>
+              <span className={change !== undefined ? changeColor(change.pct) : "text-steel-gray/60"}>
+                {change !== undefined ? `${formatSignedPct(change.pct)}%` : "—"}
+              </span>
+            </span>
+          );
+        })}
+      </span>
+    </div>
+  );
+}

--- a/apps/stat.mtlf.me/src/components/dashboard/indicator-card.tsx
+++ b/apps/stat.mtlf.me/src/components/dashboard/indicator-card.tsx
@@ -34,6 +34,12 @@ const changeColor = (raw: string): string => {
   return "text-steel-gray";
 };
 
+const formatIndicatorValue = (indicator: Indicator): { value: string; unit: string } => {
+  const valueNum = toNum(indicator.value);
+  const decimals = indicator.unit === "%" ? 2 : valueNum >= 1000 ? 0 : 4;
+  return { value: formatNumber(valueNum, decimals), unit: indicator.unit };
+};
+
 function ChangeRow({ period, change }: { period: Range; change: IndicatorChange }) {
   return (
     <div className="flex items-baseline justify-between gap-2 font-mono text-[11px]">
@@ -46,8 +52,7 @@ function ChangeRow({ period, change }: { period: Range; change: IndicatorChange 
 }
 
 export function IndicatorCard({ indicator }: IndicatorCardProps) {
-  const valueNum = toNum(indicator.value);
-  const decimals = indicator.unit === "%" ? 2 : valueNum >= 1000 ? 0 : 4;
+  const { value, unit } = formatIndicatorValue(indicator);
 
   return (
     <div className="border border-steel-gray/40 bg-card p-4 hover:border-electric-cyan transition-colors">
@@ -59,12 +64,8 @@ export function IndicatorCard({ indicator }: IndicatorCardProps) {
       </h3>
 
       <div className="mt-3 flex items-baseline gap-2">
-        <span className="font-mono text-2xl text-cyber-green">
-          {formatNumber(valueNum, decimals)}
-        </span>
-        <span className="font-mono text-xs uppercase text-steel-gray">
-          {indicator.unit}
-        </span>
+        <span className="font-mono text-2xl text-cyber-green">{value}</span>
+        <span className="font-mono text-xs uppercase text-steel-gray">{unit}</span>
       </div>
 
       {indicator.changes !== undefined && (
@@ -86,8 +87,7 @@ export function IndicatorCard({ indicator }: IndicatorCardProps) {
 }
 
 export function IndicatorRow({ indicator }: IndicatorCardProps) {
-  const valueNum = toNum(indicator.value);
-  const decimals = indicator.unit === "%" ? 2 : valueNum >= 1000 ? 0 : 4;
+  const { value, unit } = formatIndicatorValue(indicator);
 
   return (
     <div className="grid grid-cols-[3rem_1fr_auto_auto] items-center gap-3 border border-steel-gray/40 bg-card px-3 py-2 hover:border-electric-cyan transition-colors">
@@ -101,8 +101,8 @@ export function IndicatorRow({ indicator }: IndicatorCardProps) {
         {indicator.name}
       </span>
       <span className="font-mono text-sm tabular-nums whitespace-nowrap">
-        <span className="text-cyber-green">{formatNumber(valueNum, decimals)}</span>
-        <span className="ml-1 text-[10px] uppercase text-steel-gray">{indicator.unit}</span>
+        <span className="text-cyber-green">{value}</span>
+        <span className="ml-1 text-[10px] uppercase text-steel-gray">{unit}</span>
       </span>
       <span className="hidden sm:flex items-center gap-3 font-mono text-[11px] tabular-nums whitespace-nowrap">
         {PERIODS.map((p) => {

--- a/apps/stat.mtlf.me/src/components/dashboard/indicator-history-chart.tsx
+++ b/apps/stat.mtlf.me/src/components/dashboard/indicator-history-chart.tsx
@@ -91,17 +91,17 @@ export function IndicatorHistoryChart({
       <div className="h-[220px]">
         {error !== null && (
           <div className="flex h-full items-center justify-center font-mono text-xs uppercase text-red-400">
-            ОШИБКА: {error}
+            ERROR: {error}
           </div>
         )}
         {error === null && isLoading && (
           <div className="flex h-full items-center justify-center font-mono text-xs uppercase text-steel-gray">
-            ЗАГРУЗКА…
+            LOADING…
           </div>
         )}
         {error === null && !isLoading && points.length === 0 && (
           <div className="flex h-full items-center justify-center font-mono text-xs uppercase text-steel-gray">
-            НЕТ ДАННЫХ
+            NO DATA
           </div>
         )}
         {error === null && !isLoading && points.length > 0 && (

--- a/apps/stat.mtlf.me/src/components/dashboard/indicators-grid.test.tsx
+++ b/apps/stat.mtlf.me/src/components/dashboard/indicators-grid.test.tsx
@@ -1,0 +1,114 @@
+import type { DecimalString, Indicator } from "@/lib/api/types";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, test } from "bun:test";
+import { IndicatorsGrid } from "./indicators-grid";
+
+afterEach(cleanup);
+
+const dec = (s: string): DecimalString => s as DecimalString;
+
+const make = (id: number, name: string, description = ""): Indicator => ({
+  id,
+  name,
+  description,
+  unit: "EURMTL",
+  value: dec("100"),
+});
+
+const sample: Indicator[] = [
+  make(1, "Assets Value", "Total fund assets"),
+  make(2, "Operating Balance", "Cash and equivalents"),
+  make(3, "DEFI Total Value", "DEFI subfund assets"),
+];
+
+describe("IndicatorsGrid", () => {
+  test("renders all indicators in default LIST view", () => {
+    render(<IndicatorsGrid data={sample} isLoading={false} error={null} />);
+    expect(screen.getByText("Assets Value")).toBeDefined();
+    expect(screen.getByText("Operating Balance")).toBeDefined();
+    expect(screen.getByText("DEFI Total Value")).toBeDefined();
+  });
+
+  test("LIST is the default view (aria-pressed)", () => {
+    render(<IndicatorsGrid data={sample} isLoading={false} error={null} />);
+    expect(screen.getByRole("button", { name: "LIST" }).getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByRole("button", { name: "CARDS" }).getAttribute("aria-pressed")).toBe("false");
+  });
+
+  test("typing in search filters by name", () => {
+    render(<IndicatorsGrid data={sample} isLoading={false} error={null} />);
+    fireEvent.change(screen.getByLabelText("Search indicators"), { target: { value: "defi" } });
+    expect(screen.queryByText("Assets Value")).toBeNull();
+    expect(screen.queryByText("Operating Balance")).toBeNull();
+    expect(screen.getByText("DEFI Total Value")).toBeDefined();
+  });
+
+  test("typing in search filters by description", () => {
+    render(<IndicatorsGrid data={sample} isLoading={false} error={null} />);
+    fireEvent.change(screen.getByLabelText("Search indicators"), { target: { value: "cash" } });
+    expect(screen.queryByText("Assets Value")).toBeNull();
+    expect(screen.getByText("Operating Balance")).toBeDefined();
+  });
+
+  test("name match ranks above description match", () => {
+    const items: Indicator[] = [
+      make(10, "Foo Bar", "this contains DEFI in description"),
+      make(11, "DEFI Subfund", "unrelated description"),
+    ];
+    render(<IndicatorsGrid data={items} isLoading={false} error={null} />);
+    fireEvent.change(screen.getByLabelText("Search indicators"), { target: { value: "defi" } });
+    const rendered = screen.getAllByText(/DEFI Subfund|Foo Bar/);
+    expect(rendered[0]?.textContent).toBe("DEFI Subfund");
+  });
+
+  test("empty/whitespace query shows full list", () => {
+    render(<IndicatorsGrid data={sample} isLoading={false} error={null} />);
+    fireEvent.change(screen.getByLabelText("Search indicators"), { target: { value: "   " } });
+    expect(screen.getByText("Assets Value")).toBeDefined();
+    expect(screen.getByText("Operating Balance")).toBeDefined();
+    expect(screen.getByText("DEFI Total Value")).toBeDefined();
+  });
+
+  test("shows NO MATCHES state for non-matching query", () => {
+    render(<IndicatorsGrid data={sample} isLoading={false} error={null} />);
+    fireEvent.change(screen.getByLabelText("Search indicators"), { target: { value: "xyzzy" } });
+    expect(screen.getByText(/NO MATCHES FOR/)).toBeDefined();
+  });
+
+  test("shows INDICATORS NOT YET COMPUTED when data is empty", () => {
+    render(<IndicatorsGrid data={[]} isLoading={false} error={null} />);
+    expect(screen.getByText("INDICATORS NOT YET COMPUTED")).toBeDefined();
+  });
+
+  test("shows error state", () => {
+    render(<IndicatorsGrid data={[]} isLoading={false} error="boom" />);
+    expect(screen.getByText("ERROR: boom")).toBeDefined();
+  });
+
+  test("CLEAR button resets query and restores full list", () => {
+    render(<IndicatorsGrid data={sample} isLoading={false} error={null} />);
+    fireEvent.change(screen.getByLabelText("Search indicators"), { target: { value: "defi" } });
+    fireEvent.click(screen.getByRole("button", { name: "CLEAR" }));
+    expect(screen.getByText("Assets Value")).toBeDefined();
+    expect(screen.getByText("Operating Balance")).toBeDefined();
+    expect(screen.getByText("DEFI Total Value")).toBeDefined();
+  });
+
+  test("counter shows filtered/total when filtering reduces count", () => {
+    render(<IndicatorsGrid data={sample} isLoading={false} error={null} />);
+    fireEvent.change(screen.getByLabelText("Search indicators"), { target: { value: "defi" } });
+    expect(screen.getByText(/1 \/ 3 INDICATORS/)).toBeDefined();
+  });
+
+  test("counter shows just total when no filter applied", () => {
+    render(<IndicatorsGrid data={sample} isLoading={false} error={null} />);
+    expect(screen.getByText("3 INDICATORS")).toBeDefined();
+  });
+
+  test("CARDS toggle switches view", () => {
+    render(<IndicatorsGrid data={sample} isLoading={false} error={null} />);
+    fireEvent.click(screen.getByRole("button", { name: "CARDS" }));
+    expect(screen.getByRole("button", { name: "CARDS" }).getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByRole("button", { name: "LIST" }).getAttribute("aria-pressed")).toBe("false");
+  });
+});

--- a/apps/stat.mtlf.me/src/components/dashboard/indicators-grid.tsx
+++ b/apps/stat.mtlf.me/src/components/dashboard/indicators-grid.tsx
@@ -1,7 +1,13 @@
 "use client";
 
+import { fuzzyScore } from "@/lib/fuzzy";
 import type { Indicator } from "@/lib/api/types";
-import { IndicatorCard } from "./indicator-card";
+import { cn } from "@/lib/utils";
+import { LayoutGrid, List, Search } from "lucide-react";
+import { useMemo, useState } from "react";
+import { IndicatorCard, IndicatorRow } from "./indicator-card";
+
+type ViewMode = "list" | "cards";
 
 interface IndicatorsGridProps {
   data: readonly Indicator[];
@@ -9,45 +15,168 @@ interface IndicatorsGridProps {
   error: string | null;
 }
 
+const scoreIndicator = (query: string, indicator: Indicator): number => {
+  if (query === "") return 1;
+  const nameScore = fuzzyScore(query, indicator.name);
+  const descScore = fuzzyScore(query, indicator.description);
+  return Math.max(nameScore * 1.5, descScore);
+};
+
 export function IndicatorsGrid({ data, isLoading, error }: IndicatorsGridProps) {
+  const [query, setQuery] = useState("");
+  const [view, setView] = useState<ViewMode>("list");
+
+  const filtered = useMemo(() => {
+    const q = query.trim();
+    if (q === "") return data;
+    return data
+      .map((indicator) => ({ indicator, score: scoreIndicator(q, indicator) }))
+      .filter((entry) => entry.score > 0)
+      .sort((a, b) => b.score - a.score)
+      .map((entry) => entry.indicator);
+  }, [data, query]);
+
   return (
     <section className="border border-cyber-green bg-background p-6">
-      <div className="mb-4 flex items-baseline justify-between">
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
         <h2 className="font-mono text-xl uppercase tracking-wider text-cyber-green">
-          ИНДИКАТОРЫ ФОНДА
+          FUND INDICATORS
         </h2>
-        {!isLoading && error === null && (
-          <span className="font-mono text-xs uppercase text-steel-gray">
-            {data.length} ПОКАЗАТЕЛЕЙ
-          </span>
+        <div className="flex items-center gap-3">
+          {!isLoading && error === null && (
+            <span className="font-mono text-xs uppercase text-steel-gray">
+              {filtered.length}
+              {query !== "" && filtered.length !== data.length ? ` / ${data.length}` : ""} INDICATORS
+            </span>
+          )}
+          <ViewToggle value={view} onChange={setView} />
+        </div>
+      </div>
+
+      <div className="mb-4 flex items-center gap-2 border border-steel-gray/40 bg-card px-3 py-2 focus-within:border-electric-cyan transition-colors">
+        <Search className="h-3.5 w-3.5 text-steel-gray" aria-hidden />
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="SEARCH INDICATORS BY NAME OR DESCRIPTION"
+          className="flex-1 bg-transparent font-mono text-xs uppercase tracking-wider text-foreground placeholder:text-steel-gray focus:outline-none"
+          aria-label="Search indicators"
+        />
+        {query !== "" && (
+          <button
+            type="button"
+            onClick={() => setQuery("")}
+            className="font-mono text-[10px] uppercase tracking-wider text-steel-gray hover:text-cyber-green transition-colors"
+          >
+            CLEAR
+          </button>
         )}
       </div>
 
       {error !== null && (
         <div className="border border-red-500 bg-red-500/10 p-4 font-mono text-sm text-red-400">
-          ОШИБКА: {error}
+          ERROR: {error}
         </div>
       )}
 
       {error === null && isLoading && (
-        <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-          {Array.from({ length: 8 }).map((_, i) => (
-            <div key={i} className="h-44 border border-steel-gray/30 bg-steel-gray/10 animate-pulse" />
-          ))}
-        </div>
+        view === "cards"
+          ? (
+            <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+              {Array.from({ length: 8 }).map((_, i) => (
+                <div key={i} className="h-44 border border-steel-gray/30 bg-steel-gray/10 animate-pulse" />
+              ))}
+            </div>
+          )
+          : (
+            <div className="space-y-2">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <div key={i} className="h-10 border border-steel-gray/30 bg-steel-gray/10 animate-pulse" />
+              ))}
+            </div>
+          )
       )}
 
       {error === null && !isLoading && data.length === 0 && (
         <div className="border border-steel-gray/40 bg-steel-gray/10 p-8 text-center font-mono text-sm uppercase tracking-wider text-steel-gray">
-          ИНДИКАТОРЫ ЕЩЁ НЕ РАССЧИТАНЫ
+          INDICATORS NOT YET COMPUTED
         </div>
       )}
 
-      {error === null && !isLoading && data.length > 0 && (
-        <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-          {data.map((indicator) => <IndicatorCard key={indicator.id} indicator={indicator} />)}
+      {error === null && !isLoading && data.length > 0 && filtered.length === 0 && (
+        <div className="border border-steel-gray/40 bg-steel-gray/10 p-8 text-center font-mono text-sm uppercase tracking-wider text-steel-gray">
+          NO MATCHES FOR &quot;{query}&quot;
         </div>
       )}
+
+      {error === null && !isLoading && filtered.length > 0 && (
+        view === "cards"
+          ? (
+            <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+              {filtered.map((indicator) => <IndicatorCard key={indicator.id} indicator={indicator} />)}
+            </div>
+          )
+          : (
+            <div className="space-y-1.5">
+              {filtered.map((indicator) => <IndicatorRow key={indicator.id} indicator={indicator} />)}
+            </div>
+          )
+      )}
     </section>
+  );
+}
+
+function ViewToggle({ value, onChange }: { value: ViewMode; onChange: (v: ViewMode) => void }) {
+  return (
+    <div
+      role="group"
+      aria-label="View mode"
+      className="inline-flex border border-electric-cyan bg-background"
+    >
+      <ViewToggleButton
+        active={value === "list"}
+        onClick={() => onChange("list")}
+        label="LIST"
+        icon={<List className="h-3.5 w-3.5" aria-hidden />}
+      />
+      <ViewToggleButton
+        active={value === "cards"}
+        onClick={() => onChange("cards")}
+        label="CARDS"
+        icon={<LayoutGrid className="h-3.5 w-3.5" aria-hidden />}
+        bordered
+      />
+    </div>
+  );
+}
+
+function ViewToggleButton(
+  { active, onClick, label, icon, bordered = false }: {
+    active: boolean;
+    onClick: () => void;
+    label: string;
+    icon: React.ReactNode;
+    bordered?: boolean;
+  },
+) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      aria-label={label}
+      className={cn(
+        "inline-flex items-center gap-1.5 px-3 py-2 font-mono text-[10px] uppercase tracking-wider transition-colors",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyber-green",
+        bordered && "border-l border-electric-cyan",
+        active
+          ? "bg-electric-cyan text-background"
+          : "text-electric-cyan hover:bg-electric-cyan/10",
+      )}
+    >
+      {icon}
+      <span className="hidden sm:inline">{label}</span>
+    </button>
   );
 }

--- a/apps/stat.mtlf.me/src/components/dashboard/indicators-grid.tsx
+++ b/apps/stat.mtlf.me/src/components/dashboard/indicators-grid.tsx
@@ -16,7 +16,6 @@ interface IndicatorsGridProps {
 }
 
 const scoreIndicator = (query: string, indicator: Indicator): number => {
-  if (query === "") return 1;
   const nameScore = fuzzyScore(query, indicator.name);
   const descScore = fuzzyScore(query, indicator.description);
   return Math.max(nameScore * 1.5, descScore);
@@ -36,6 +35,16 @@ export function IndicatorsGrid({ data, isLoading, error }: IndicatorsGridProps) 
       .map((entry) => entry.indicator);
   }, [data, query]);
 
+  const state: "error" | "loading" | "empty" | "no-matches" | "ready" = error !== null
+    ? "error"
+    : isLoading
+    ? "loading"
+    : data.length === 0
+    ? "empty"
+    : filtered.length === 0
+    ? "no-matches"
+    : "ready";
+
   return (
     <section className="border border-cyber-green bg-background p-6">
       <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
@@ -43,7 +52,7 @@ export function IndicatorsGrid({ data, isLoading, error }: IndicatorsGridProps) 
           FUND INDICATORS
         </h2>
         <div className="flex items-center gap-3">
-          {!isLoading && error === null && (
+          {state === "ready" && (
             <span className="font-mono text-xs uppercase text-steel-gray">
               {filtered.length}
               {query !== "" && filtered.length !== data.length ? ` / ${data.length}` : ""} INDICATORS
@@ -74,56 +83,64 @@ export function IndicatorsGrid({ data, isLoading, error }: IndicatorsGridProps) 
         )}
       </div>
 
-      {error !== null && (
+      {state === "error" && (
         <div className="border border-red-500 bg-red-500/10 p-4 font-mono text-sm text-red-400">
           ERROR: {error}
         </div>
       )}
 
-      {error === null && isLoading && (
-        view === "cards"
-          ? (
-            <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-              {Array.from({ length: 8 }).map((_, i) => (
-                <div key={i} className="h-44 border border-steel-gray/30 bg-steel-gray/10 animate-pulse" />
-              ))}
-            </div>
-          )
-          : (
-            <div className="space-y-2">
-              {Array.from({ length: 6 }).map((_, i) => (
-                <div key={i} className="h-10 border border-steel-gray/30 bg-steel-gray/10 animate-pulse" />
-              ))}
-            </div>
-          )
+      {state === "loading" && (
+        <IndicatorListLayout view={view}>
+          {Array.from({ length: view === "cards" ? 8 : 6 }).map((_, i) => (
+            <div
+              key={i}
+              className={cn(
+                "border border-steel-gray/30 bg-steel-gray/10 animate-pulse",
+                view === "cards" ? "h-44" : "h-10",
+              )}
+            />
+          ))}
+        </IndicatorListLayout>
       )}
 
-      {error === null && !isLoading && data.length === 0 && (
-        <div className="border border-steel-gray/40 bg-steel-gray/10 p-8 text-center font-mono text-sm uppercase tracking-wider text-steel-gray">
-          INDICATORS NOT YET COMPUTED
-        </div>
+      {state === "empty" && (
+        <EmptyState>INDICATORS NOT YET COMPUTED</EmptyState>
       )}
 
-      {error === null && !isLoading && data.length > 0 && filtered.length === 0 && (
-        <div className="border border-steel-gray/40 bg-steel-gray/10 p-8 text-center font-mono text-sm uppercase tracking-wider text-steel-gray">
-          NO MATCHES FOR &quot;{query}&quot;
-        </div>
+      {state === "no-matches" && (
+        <EmptyState>NO MATCHES FOR &quot;{query}&quot;</EmptyState>
       )}
 
-      {error === null && !isLoading && filtered.length > 0 && (
-        view === "cards"
-          ? (
-            <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-              {filtered.map((indicator) => <IndicatorCard key={indicator.id} indicator={indicator} />)}
-            </div>
-          )
-          : (
-            <div className="space-y-1.5">
-              {filtered.map((indicator) => <IndicatorRow key={indicator.id} indicator={indicator} />)}
-            </div>
-          )
+      {state === "ready" && (
+        <IndicatorListLayout view={view}>
+          {filtered.map((indicator) =>
+            view === "cards"
+              ? <IndicatorCard key={indicator.id} indicator={indicator} />
+              : <IndicatorRow key={indicator.id} indicator={indicator} />
+          )}
+        </IndicatorListLayout>
       )}
     </section>
+  );
+}
+
+function IndicatorListLayout({ view, children }: { view: ViewMode; children: React.ReactNode }) {
+  return (
+    <div
+      className={view === "cards"
+        ? "grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+        : "space-y-1.5"}
+    >
+      {children}
+    </div>
+  );
+}
+
+function EmptyState({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="border border-steel-gray/40 bg-steel-gray/10 p-8 text-center font-mono text-sm uppercase tracking-wider text-steel-gray">
+      {children}
+    </div>
   );
 }
 

--- a/apps/stat.mtlf.me/src/components/dashboard/subfund-pie-chart.tsx
+++ b/apps/stat.mtlf.me/src/components/dashboard/subfund-pie-chart.tsx
@@ -2,6 +2,8 @@
 
 import type { SubfundSlice } from "@/lib/api/types";
 import { formatNumber } from "@/lib/utils";
+import { ArrowRight } from "lucide-react";
+import Link from "next/link";
 import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip, type TooltipProps } from "recharts";
 
 const PALETTE = [
@@ -14,6 +16,8 @@ const PALETTE = [
 interface SubfundPieChartProps {
   slices: readonly SubfundSlice[];
   date: string;
+  totalValue?: string;
+  totalUnit?: string;
 }
 
 interface ChartDatum {
@@ -44,7 +48,7 @@ const toFiniteNumber = (raw: string): number => {
   return Number.isFinite(n) ? n : 0;
 };
 
-export function SubfundPieChart({ slices, date }: SubfundPieChartProps) {
+export function SubfundPieChart({ slices, date, totalValue, totalUnit }: SubfundPieChartProps) {
   const data: ChartDatum[] = slices.map((slice) => ({
     name: slice.name,
     value: toFiniteNumber(slice.value),
@@ -55,11 +59,13 @@ export function SubfundPieChart({ slices, date }: SubfundPieChartProps) {
   const total = data.reduce((sum, d) => sum + d.value, 0);
   const enriched = data.map((d) => ({ ...d, pct: total > 0 ? (d.value / total) * 100 : 0 }));
 
+  const totalNum = totalValue !== undefined ? toFiniteNumber(totalValue) : null;
+
   return (
     <div className="border border-cyber-green bg-card p-6">
       <div className="mb-1 flex items-baseline justify-between">
         <h2 className="font-mono text-xl uppercase tracking-wider text-cyber-green">
-          СТРУКТУРА САБФОНДОВ
+          SUBFUND STRUCTURE
         </h2>
         <span className="font-mono text-xs uppercase text-steel-gray">{date}</span>
       </div>
@@ -86,7 +92,7 @@ export function SubfundPieChart({ slices, date }: SubfundPieChartProps) {
         </ResponsiveContainer>
       </div>
 
-      <ul className="mt-4 grid grid-cols-2 gap-2 sm:grid-cols-4">
+      <ul className="mt-4 flex flex-wrap justify-center gap-x-6 gap-y-2">
         {enriched.map((d, i) => (
           <li key={d.name} className="flex items-center gap-2 font-mono text-xs">
             <span
@@ -101,6 +107,33 @@ export function SubfundPieChart({ slices, date }: SubfundPieChartProps) {
           </li>
         ))}
       </ul>
+
+      <div className="mt-6 flex flex-wrap items-end justify-between gap-4 border-t border-steel-gray/30 pt-4">
+        <div>
+          <div className="font-mono text-[10px] uppercase tracking-widest text-steel-gray">
+            TOTAL ASSETS VALUE (I3)
+          </div>
+          <div className="mt-1 font-mono">
+            {totalNum !== null
+              ? (
+                <>
+                  <span className="text-3xl text-cyber-green">{formatNumber(totalNum, 2)}</span>
+                  {totalUnit !== undefined && (
+                    <span className="ml-2 text-xs uppercase text-steel-gray">{totalUnit}</span>
+                  )}
+                </>
+              )
+              : <span className="text-2xl text-steel-gray">—</span>}
+          </div>
+        </div>
+        <Link
+          href="/fund"
+          className="inline-flex items-center gap-2 border border-electric-cyan bg-background px-4 py-2 font-mono text-xs uppercase tracking-wider text-electric-cyan hover:bg-electric-cyan hover:text-background transition-colors"
+        >
+          DETAILS
+          <ArrowRight className="h-3.5 w-3.5" />
+        </Link>
+      </div>
     </div>
   );
 }

--- a/apps/stat.mtlf.me/src/components/dashboard/subfund-pie-chart.tsx
+++ b/apps/stat.mtlf.me/src/components/dashboard/subfund-pie-chart.tsx
@@ -48,18 +48,27 @@ const toFiniteNumber = (raw: string): number => {
   return Number.isFinite(n) ? n : 0;
 };
 
-export function SubfundPieChart({ slices, date, totalValue, totalUnit }: SubfundPieChartProps) {
-  const data: ChartDatum[] = slices.map((slice) => ({
-    name: slice.name,
-    value: toFiniteNumber(slice.value),
-    rawValue: slice.value,
-    address: slice.address,
-    pct: 0,
-  }));
-  const total = data.reduce((sum, d) => sum + d.value, 0);
-  const enriched = data.map((d) => ({ ...d, pct: total > 0 ? (d.value / total) * 100 : 0 }));
+const parseFiniteOrNull = (raw: string | undefined): number | null => {
+  if (raw === undefined) return null;
+  const n = parseFloat(raw);
+  return Number.isFinite(n) ? n : null;
+};
 
-  const totalNum = totalValue !== undefined ? toFiniteNumber(totalValue) : null;
+export function SubfundPieChart({ slices, date, totalValue, totalUnit }: SubfundPieChartProps) {
+  const sliceValues = slices.map((s) => toFiniteNumber(s.value));
+  const total = sliceValues.reduce((sum, v) => sum + v, 0);
+  const enriched: ChartDatum[] = slices.map((slice, i) => {
+    const value = sliceValues[i] ?? 0;
+    return {
+      name: slice.name,
+      value,
+      rawValue: slice.value,
+      address: slice.address,
+      pct: total > 0 ? (value / total) * 100 : 0,
+    };
+  });
+
+  const totalNum = parseFiniteOrNull(totalValue);
 
   return (
     <div className="border border-cyber-green bg-card p-6">

--- a/apps/stat.mtlf.me/src/components/layout/footer.tsx
+++ b/apps/stat.mtlf.me/src/components/layout/footer.tsx
@@ -10,17 +10,17 @@ export function Footer() {
       description="MONTELIBERO FOUNDATION PORTFOLIO STATISTICS // REAL-TIME STELLAR BLOCKCHAIN DATA"
       sections={[
         {
-          title: "РЕСУРСЫ",
+          title: "RESOURCES",
           links: [
             { href: "https://github.com/mtlprog/dreadnought", label: "GITHUB", icon: Github },
-            { href: "https://montelibero.org/mtl-fund/", label: "ФОНД MONTELIBERO", icon: ExternalLink },
+            { href: "https://montelibero.org/mtl-fund/", label: "MONTELIBERO FUND", icon: ExternalLink },
           ],
         },
         {
-          title: "СООБЩЕСТВО",
+          title: "COMMUNITY",
           links: [
             { href: "https://t.me/Montelibero_ru", label: "MONTELIBERO", icon: MessageCircle },
-            { href: "https://t.me/montelibero_agora/43852", label: "ГИЛЬДИЯ ПРОГРАММИСТОВ", icon: MessageCircle },
+            { href: "https://t.me/montelibero_agora/43852", label: "DEVELOPERS GUILD", icon: MessageCircle },
           ],
         },
       ]}

--- a/apps/stat.mtlf.me/src/components/portfolio/filter-toggle-panel.tsx
+++ b/apps/stat.mtlf.me/src/components/portfolio/filter-toggle-panel.tsx
@@ -13,7 +13,7 @@ export function FilterTogglePanel({ hideIlliquidTokens, onHideIlliquidTokensChan
     <Card className="p-4 border-0 bg-card text-card-foreground">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-6">
-          <span className="text-sm font-mono uppercase tracking-wider text-steel-gray">ФИЛЬТРЫ:</span>
+          <span className="text-sm font-mono uppercase tracking-wider text-steel-gray">FILTERS:</span>
 
           {/* Hide Illiquid Tokens Toggle */}
           <label className="flex items-center gap-3 cursor-pointer group">
@@ -28,7 +28,7 @@ export function FilterTogglePanel({ hideIlliquidTokens, onHideIlliquidTokensChan
               <div className="absolute left-0.5 top-0.5 w-4 h-4 bg-steel-gray peer-checked:bg-cyber-green peer-checked:translate-x-5 transition-transform duration-200" />
             </div>
             <span className="text-sm font-mono uppercase tracking-wider text-foreground group-hover:text-cyber-green transition-colors">
-              СКРЫТЬ НЕЛИКВИДНЫЕ ТОКЕНЫ
+              HIDE ILLIQUID TOKENS
             </span>
           </label>
         </div>
@@ -36,7 +36,7 @@ export function FilterTogglePanel({ hideIlliquidTokens, onHideIlliquidTokensChan
         {/* Info indicator */}
         {hideIlliquidTokens && (
           <div className="text-xs font-mono text-warning-amber uppercase tracking-wider">
-            ФИЛЬТР АКТИВЕН
+            FILTER ACTIVE
           </div>
         )}
       </div>

--- a/apps/stat.mtlf.me/src/components/portfolio/fund-structure-table.tsx
+++ b/apps/stat.mtlf.me/src/components/portfolio/fund-structure-table.tsx
@@ -24,8 +24,8 @@ function formatPriceTooltip(details?: PriceDetails, showOrderbookDetails = true)
   if (details === null || details === undefined) {
     return (
       <div className="font-mono">
-        <div className="text-warning-amber">НЕТ ДАННЫХ</div>
-        <div className="text-xs text-steel-gray mt-1">Цена недоступна</div>
+        <div className="text-warning-amber">NO DATA</div>
+        <div className="text-xs text-steel-gray mt-1">Price unavailable</div>
       </div>
     );
   }
@@ -35,7 +35,7 @@ function formatPriceTooltip(details?: PriceDetails, showOrderbookDetails = true)
     return (
       <div className="font-mono space-y-2">
         <div className="text-cyber-green uppercase text-xs font-bold border-b border-cyber-green/30 pb-1">
-          ЛУЧШАЯ ЦЕНА: {details.chosenSource === "path" ? "ПОИСК ПУТИ" : "ORDERBOOK"}
+          BEST PRICE: {details.chosenSource === "path" ? "PATH FINDING" : "ORDERBOOK"}
         </div>
 
         {/* Price comparison */}
@@ -61,14 +61,14 @@ function formatPriceTooltip(details?: PriceDetails, showOrderbookDetails = true)
         {/* Show details of chosen source */}
         {details.chosenSource === "path" && details.pathDetails !== null && details.pathDetails !== undefined && (
           <div className="text-[10px] text-steel-gray">
-            <div className="uppercase font-bold mb-1">ДЕТАЛИ ПУТИ:</div>
+            <div className="uppercase font-bold mb-1">PATH DETAILS:</div>
             {formatPriceTooltip(details.pathDetails, false)}
           </div>
         )}
         {details.chosenSource === "orderbook" && details.orderbookDetails !== null
           && details.orderbookDetails !== undefined && (
           <div className="text-[10px] text-steel-gray">
-            <div className="uppercase font-bold mb-1">ДЕТАЛИ ORDERBOOK:</div>
+            <div className="uppercase font-bold mb-1">ORDERBOOK DETAILS:</div>
             {formatPriceTooltip(details.orderbookDetails, true)}
           </div>
         )}
@@ -81,18 +81,18 @@ function formatPriceTooltip(details?: PriceDetails, showOrderbookDetails = true)
     return (
       <div className="font-mono space-y-2">
         <div className="text-warning-amber uppercase text-xs font-bold border-b border-warning-amber/30 pb-1">
-          ПРЯМОЙ ORDERBOOK
+          DIRECT ORDERBOOK
         </div>
 
         <div className="text-[10px] space-y-1">
           <div className="flex justify-between gap-4">
-            <span className="text-steel-gray uppercase font-bold">ТИП ЦЕНЫ:</span>
+            <span className="text-steel-gray uppercase font-bold">PRICE TYPE:</span>
             <span
               className={`${
                 details.priceType === "bid" ? "text-cyber-green" : "text-warning-amber"
               } font-bold uppercase`}
             >
-              {details.priceType === "bid" ? "BID (ПОКУПКА)" : "ASK (ПРОДАЖА)"}
+              {details.priceType === "bid" ? "BID (BUY)" : "ASK (SELL)"}
             </span>
           </div>
         </div>
@@ -218,7 +218,7 @@ function formatPriceTooltip(details?: PriceDetails, showOrderbookDetails = true)
     return (
       <div className="font-mono space-y-2">
         <div className="text-electric-cyan uppercase text-xs font-bold border-b border-electric-cyan/30 pb-1">
-          ПОИСК ПУТИ
+          PATH FINDING
         </div>
 
         {/* Show trade amounts if available (for full balance tooltips) */}
@@ -226,15 +226,15 @@ function formatPriceTooltip(details?: PriceDetails, showOrderbookDetails = true)
           && details.destinationAmount !== null && details.destinationAmount !== undefined && (
           <div className="text-[10px] space-y-0.5 pb-2 border-b border-steel-gray/30">
             <div className="flex justify-between gap-4">
-              <span className="text-steel-gray uppercase font-bold">ПРОДАЖА:</span>
+              <span className="text-steel-gray uppercase font-bold">SELL:</span>
               <span className="text-warning-amber">{formatNumber(parseFloat(details.sourceAmount), 7)}</span>
             </div>
             <div className="flex justify-between gap-4">
-              <span className="text-steel-gray uppercase font-bold">ПОЛУЧЕНИЕ:</span>
+              <span className="text-steel-gray uppercase font-bold">RECEIVE:</span>
               <span className="text-cyber-green">{formatNumber(parseFloat(details.destinationAmount), 7)}</span>
             </div>
             <div className="flex justify-between gap-4">
-              <span className="text-steel-gray uppercase font-bold">ЭФФЕКТ. ЦЕНА:</span>
+              <span className="text-steel-gray uppercase font-bold">EFFECTIVE PRICE:</span>
               <span className="text-electric-cyan">
                 {formatNumber(parseFloat(details.destinationAmount) / parseFloat(details.sourceAmount), 7)}
               </span>
@@ -345,7 +345,7 @@ function formatPriceTooltip(details?: PriceDetails, showOrderbookDetails = true)
                   )}
 
                   {/* No data message */}
-                  {hop.orderbook.bestSource === "none" && <div className="text-steel-gray italic">нет данных</div>}
+                  {hop.orderbook.bestSource === "none" && <div className="text-steel-gray italic">no data</div>}
                 </div>
               )}
             </div>
@@ -368,11 +368,11 @@ function AccountTypeIndicator({ type }: { type: "issuer" | "subfond" | "mutual" 
   };
 
   const labels = {
-    issuer: "ЭМИТЕНТ",
-    subfond: "САБФОНД",
-    mutual: "МУТУАЛ",
-    operational: "ОПЕРАЦ.",
-    other: "ПРОЧЕЕ",
+    issuer: "ISSUER",
+    subfond: "SUBFUND",
+    mutual: "MUTUAL",
+    operational: "OPERATIONAL",
+    other: "OTHER",
   };
 
   return (
@@ -412,7 +412,7 @@ function AccountSection(
             <StellarAccount accountId={account.id} explorer={explorer} className="mt-1" />
           </div>
           <div className="text-right">
-            <div className="text-sm font-mono text-steel-gray uppercase">ИТОГО СЧЁТА</div>
+            <div className="text-sm font-mono text-steel-gray uppercase">ACCOUNT TOTAL</div>
             <div className="text-lg font-mono text-warning-amber">
               {formatNumber(account.totalEURMTL, 2)} EURMTL
             </div>
@@ -485,21 +485,21 @@ function AccountSection(
                         ? (
                           <div className="font-mono space-y-2">
                             <div className="text-purple-400 uppercase text-xs font-bold border-b border-purple-400/30 pb-1">
-                              ОЦЕНКА NFT ФОНДА
+                              FUND NFT VALUATION
                             </div>
                             <div className="text-[10px] space-y-0.5">
-                              <div className="text-steel-gray">Источник оценки:</div>
+                              <div className="text-steel-gray">Valuation source:</div>
                               <div className="text-electric-cyan font-mono text-[9px] break-all">
                                 {token.nftValuationAccount}
                               </div>
                             </div>
                             <div className="text-[10px] space-y-0.5">
-                              <div className="text-steel-gray">Статус:</div>
-                              <div className="text-warning-amber">НОМИНАЛЬНАЯ (НЕ ЛИКВИДНА)</div>
+                              <div className="text-steel-gray">Status:</div>
+                              <div className="text-warning-amber">NOMINAL (ILLIQUID)</div>
                             </div>
                             <div className="text-[10px] space-y-0.5">
-                              <div className="text-steel-gray">Баланс NFT:</div>
-                              <div className="text-foreground">0.0000001 (1 струп)</div>
+                              <div className="text-steel-gray">NFT balance:</div>
+                              <div className="text-foreground">0.0000001 (1 strup)</div>
                             </div>
                           </div>
                         )
@@ -507,20 +507,20 @@ function AccountSection(
                         ? (
                           <div className="font-mono space-y-2">
                             <div className="text-electric-cyan uppercase text-xs font-bold border-b border-electric-cyan/30 pb-1">
-                              ЦЕНА ИЗ DATA ENTRY
+                              PRICE FROM DATA ENTRY
                             </div>
                             <div className="text-[10px] space-y-0.5">
-                              <div className="text-steel-gray">Источник:</div>
+                              <div className="text-steel-gray">Source:</div>
                               <div className="text-electric-cyan font-mono text-[9px] break-all">
                                 {token.nftValuationAccount}
                               </div>
                             </div>
                             <div className="text-[10px] space-y-0.5">
-                              <div className="text-steel-gray">Тип оценки:</div>
+                              <div className="text-steel-gray">Valuation type:</div>
                               <div className="text-foreground">{token.asset.code}_1COST</div>
                             </div>
                             <div className="text-[10px] space-y-0.5">
-                              <div className="text-steel-gray">Цена за единицу:</div>
+                              <div className="text-steel-gray">Unit price:</div>
                               <div className="text-cyber-green">
                                 {token.priceInEURMTL != null ? formatNumber(parseFloat(token.priceInEURMTL), 7) : "—"}
                                 {" "}
@@ -557,21 +557,21 @@ function AccountSection(
                         ? (
                           <div className="font-mono space-y-2">
                             <div className="text-purple-400 uppercase text-xs font-bold border-b border-purple-400/30 pb-1">
-                              ОЦЕНКА NFT ФОНДА
+                              FUND NFT VALUATION
                             </div>
                             <div className="text-[10px] space-y-0.5">
-                              <div className="text-steel-gray">Источник оценки:</div>
+                              <div className="text-steel-gray">Valuation source:</div>
                               <div className="text-electric-cyan font-mono text-[9px] break-all">
                                 {token.nftValuationAccount}
                               </div>
                             </div>
                             <div className="text-[10px] space-y-0.5">
-                              <div className="text-steel-gray">Статус:</div>
-                              <div className="text-warning-amber">НОМИНАЛЬНАЯ (НЕ ЛИКВИДНА)</div>
+                              <div className="text-steel-gray">Status:</div>
+                              <div className="text-warning-amber">NOMINAL (ILLIQUID)</div>
                             </div>
                             <div className="text-[10px] space-y-0.5">
-                              <div className="text-steel-gray">Конверсия:</div>
-                              <div className="text-foreground">EURMTL → XLM по курсу DEX</div>
+                              <div className="text-steel-gray">Conversion:</div>
+                              <div className="text-foreground">EURMTL → XLM at DEX rate</div>
                             </div>
                           </div>
                         )
@@ -579,27 +579,27 @@ function AccountSection(
                         ? (
                           <div className="font-mono space-y-2">
                             <div className="text-electric-cyan uppercase text-xs font-bold border-b border-electric-cyan/30 pb-1">
-                              ЦЕНА ИЗ DATA ENTRY
+                              PRICE FROM DATA ENTRY
                             </div>
                             <div className="text-[10px] space-y-0.5">
-                              <div className="text-steel-gray">Источник:</div>
+                              <div className="text-steel-gray">Source:</div>
                               <div className="text-electric-cyan font-mono text-[9px] break-all">
                                 {token.nftValuationAccount}
                               </div>
                             </div>
                             <div className="text-[10px] space-y-0.5">
-                              <div className="text-steel-gray">Тип оценки:</div>
+                              <div className="text-steel-gray">Valuation type:</div>
                               <div className="text-foreground">{token.asset.code}_1COST</div>
                             </div>
                             <div className="text-[10px] space-y-0.5">
-                              <div className="text-steel-gray">Цена за единицу:</div>
+                              <div className="text-steel-gray">Unit price:</div>
                               <div className="text-cyber-green">
                                 {token.priceInXLM != null ? formatNumber(parseFloat(token.priceInXLM), 7) : "—"} XLM
                               </div>
                             </div>
                             <div className="text-[10px] space-y-0.5">
-                              <div className="text-steel-gray">Конверсия:</div>
-                              <div className="text-foreground">EURMTL → XLM по курсу DEX</div>
+                              <div className="text-steel-gray">Conversion:</div>
+                              <div className="text-foreground">EURMTL → XLM at DEX rate</div>
                             </div>
                           </div>
                         )
@@ -632,14 +632,14 @@ function AccountSection(
                         ? (
                           <div className="font-mono space-y-2">
                             <div className="text-purple-400 uppercase text-xs font-bold border-b border-purple-400/30 pb-1">
-                              ОЦЕНКА NFT ФОНДА
+                              FUND NFT VALUATION
                             </div>
                             <div className="text-[10px] space-y-0.5">
                               <div className="text-warning-amber uppercase font-bold">
-                                ⚠ НЕ ВХОДИТ В ЛИКВИДНЫЙ ИТОГ
+                                ⚠ NOT INCLUDED IN LIQUID TOTAL
                               </div>
                               <div className="text-steel-gray mt-2">
-                                NFT включены только в номинальный итог фонда
+                                NFTs are only counted in the nominal fund total
                               </div>
                             </div>
                           </div>
@@ -648,14 +648,14 @@ function AccountSection(
                         ? (
                           <div className="font-mono space-y-2">
                             <div className="text-electric-cyan uppercase text-xs font-bold border-b border-electric-cyan/30 pb-1">
-                              СТОИМОСТЬ ИЗ DATA ENTRY
+                              VALUE FROM DATA ENTRY
                             </div>
                             <div className="text-[10px] space-y-0.5">
-                              <div className="text-steel-gray">Расчет:</div>
-                              <div className="text-foreground">Цена × Количество</div>
+                              <div className="text-steel-gray">Calculation:</div>
+                              <div className="text-foreground">Price × Quantity</div>
                             </div>
                             <div className="text-[10px] space-y-0.5">
-                              <div className="text-steel-gray">Цена из:</div>
+                              <div className="text-steel-gray">Price from:</div>
                               <div className="text-electric-cyan">{token.asset.code}_1COST</div>
                             </div>
                           </div>
@@ -689,14 +689,14 @@ function AccountSection(
                         ? (
                           <div className="font-mono space-y-2">
                             <div className="text-purple-400 uppercase text-xs font-bold border-b border-purple-400/30 pb-1">
-                              ОЦЕНКА NFT ФОНДА
+                              FUND NFT VALUATION
                             </div>
                             <div className="text-[10px] space-y-0.5">
                               <div className="text-warning-amber uppercase font-bold">
-                                ⚠ НЕ ВХОДИТ В ЛИКВИДНЫЙ ИТОГ
+                                ⚠ NOT INCLUDED IN LIQUID TOTAL
                               </div>
                               <div className="text-steel-gray mt-2">
-                                NFT включены только в номинальный итог фонда
+                                NFTs are only counted in the nominal fund total
                               </div>
                             </div>
                           </div>
@@ -705,15 +705,15 @@ function AccountSection(
                         ? (
                           <div className="font-mono space-y-2">
                             <div className="text-electric-cyan uppercase text-xs font-bold border-b border-electric-cyan/30 pb-1">
-                              СТОИМОСТЬ ИЗ DATA ENTRY
+                              VALUE FROM DATA ENTRY
                             </div>
                             <div className="text-[10px] space-y-0.5">
-                              <div className="text-steel-gray">Расчет:</div>
-                              <div className="text-foreground">Цена × Количество</div>
+                              <div className="text-steel-gray">Calculation:</div>
+                              <div className="text-foreground">Price × Quantity</div>
                             </div>
                             <div className="text-[10px] space-y-0.5">
-                              <div className="text-steel-gray">Конверсия:</div>
-                              <div className="text-foreground">EURMTL → XLM по курсу DEX</div>
+                              <div className="text-steel-gray">Conversion:</div>
+                              <div className="text-foreground">EURMTL → XLM at DEX rate</div>
                             </div>
                           </div>
                         )
@@ -739,8 +739,8 @@ export function FundStructureTable({ fundData, explorer, isLoading = false }: Fu
     return (
       <Card className="p-8 border-0 bg-background text-white">
         <div className="text-center">
-          <div className="text-2xl text-cyber-green mb-4">⏳ ЗАГРУЗКА СТРУКТУРЫ ФОНДА...</div>
-          <div className="text-steel-gray">Получение данных по всем счетам...</div>
+          <div className="text-2xl text-cyber-green mb-4">⏳ LOADING FUND STRUCTURE...</div>
+          <div className="text-steel-gray">Fetching data for all accounts...</div>
         </div>
       </Card>
     );
@@ -769,10 +769,10 @@ export function FundStructureTable({ fundData, explorer, isLoading = false }: Fu
 
         <Card className="p-0 border-0 bg-card text-card-foreground overflow-hidden">
           <div className="bg-cyber-green text-background p-6">
-            <h2 className="text-3xl font-mono uppercase tracking-wider">СТРУКТУРА ФОНДА MONTELIBERO</h2>
+            <h2 className="text-3xl font-mono uppercase tracking-wider">MONTELIBERO FUND STRUCTURE</h2>
             {totals !== null && (
               <p className="text-lg font-mono mt-2">
-                {totals.accountCount} СЧЕТОВ // {totals.tokenCount} ТОКЕНОВ
+                {totals.accountCount} ACCOUNTS // {totals.tokenCount} TOKENS
               </p>
             )}
           </div>
@@ -784,23 +784,23 @@ export function FundStructureTable({ fundData, explorer, isLoading = false }: Fu
                 <TableHeader>
                   <TableRow className="border-steel-gray">
                     <TableHead className="text-foreground font-mono uppercase tracking-wider w-32 bg-background">
-                      ТОКЕН
+                      TOKEN
                     </TableHead>
                     <TableHead className="text-foreground font-mono uppercase tracking-wider w-40 bg-background">
-                      БАЛАНС
+                      BALANCE
                     </TableHead>
                     <TableHead className="text-foreground font-mono uppercase tracking-wider text-right w-32 bg-background">
                       <Tooltip>
                         <TooltipTrigger asChild>
                           <span className="cursor-help underline-offset-2 hover:underline">
-                            ЦЕНА (EURMTL)
+                            PRICE (EURMTL)
                           </span>
                         </TooltipTrigger>
                         <TooltipContent side="top" className="max-w-xs">
                           <div className="font-mono text-xs space-y-1">
-                            <div className="text-electric-cyan uppercase font-bold">ЦЕНА ЗА 1 ТОКЕН</div>
+                            <div className="text-electric-cyan uppercase font-bold">PRICE PER TOKEN</div>
                             <div className="text-steel-gray">
-                              Показывает цену обмена за одну единицу токена в EURMTL
+                              Exchange price for one token unit in EURMTL
                             </div>
                           </div>
                         </TooltipContent>
@@ -810,13 +810,13 @@ export function FundStructureTable({ fundData, explorer, isLoading = false }: Fu
                       <Tooltip>
                         <TooltipTrigger asChild>
                           <span className="cursor-help underline-offset-2 hover:underline">
-                            ЦЕНА (XLM)
+                            PRICE (XLM)
                           </span>
                         </TooltipTrigger>
                         <TooltipContent side="top" className="max-w-xs">
                           <div className="font-mono text-xs space-y-1">
-                            <div className="text-electric-cyan uppercase font-bold">ЦЕНА ЗА 1 ТОКЕН</div>
-                            <div className="text-steel-gray">Показывает цену обмена за одну единицу токена в XLM</div>
+                            <div className="text-electric-cyan uppercase font-bold">PRICE PER TOKEN</div>
+                            <div className="text-steel-gray">Exchange price for one token unit in XLM</div>
                           </div>
                         </TooltipContent>
                       </Tooltip>
@@ -825,14 +825,14 @@ export function FundStructureTable({ fundData, explorer, isLoading = false }: Fu
                       <Tooltip>
                         <TooltipTrigger asChild>
                           <span className="cursor-help underline-offset-2 hover:underline">
-                            СТОИМОСТЬ (EURMTL)
+                            VALUE (EURMTL)
                           </span>
                         </TooltipTrigger>
                         <TooltipContent side="top" className="max-w-xs">
                           <div className="font-mono text-xs space-y-1">
-                            <div className="text-electric-cyan uppercase font-bold">СТОИМОСТЬ ВСЕГО БАЛАНСА</div>
+                            <div className="text-electric-cyan uppercase font-bold">TOTAL BALANCE VALUE</div>
                             <div className="text-steel-gray">
-                              Показывает стоимость продажи всего баланса токена в EURMTL
+                              Sale value of the full token balance in EURMTL
                             </div>
                           </div>
                         </TooltipContent>
@@ -842,14 +842,14 @@ export function FundStructureTable({ fundData, explorer, isLoading = false }: Fu
                       <Tooltip>
                         <TooltipTrigger asChild>
                           <span className="cursor-help underline-offset-2 hover:underline">
-                            СТОИМОСТЬ (XLM)
+                            VALUE (XLM)
                           </span>
                         </TooltipTrigger>
                         <TooltipContent side="top" className="max-w-xs">
                           <div className="font-mono text-xs space-y-1">
-                            <div className="text-electric-cyan uppercase font-bold">СТОИМОСТЬ ВСЕГО БАЛАНСА</div>
+                            <div className="text-electric-cyan uppercase font-bold">TOTAL BALANCE VALUE</div>
                             <div className="text-steel-gray">
-                              Показывает стоимость продажи всего баланса токена в XLM
+                              Sale value of the full token balance in XLM
                             </div>
                           </div>
                         </TooltipContent>
@@ -878,21 +878,21 @@ export function FundStructureTable({ fundData, explorer, isLoading = false }: Fu
               <div className="flex justify-between items-center">
                 <div>
                   <span className="text-3xl font-mono uppercase tracking-wider text-cyber-green">
-                    ОБЩИЙ ИТОГ ФОНДА
+                    FUND GRAND TOTAL
                   </span>
                   <div className="text-sm font-mono text-steel-gray mt-2">
-                    {totals.accountCount} СЧЕТОВ • {totals.tokenCount} ТОКЕНОВ
+                    {totals.accountCount} ACCOUNTS • {totals.tokenCount} TOKENS
                   </div>
                 </div>
                 <div className="flex space-x-12">
                   <div className="text-right">
-                    <div className="text-sm font-mono text-steel-gray uppercase">ВСЕГО EURMTL</div>
+                    <div className="text-sm font-mono text-steel-gray uppercase">TOTAL EURMTL</div>
                     <div className="text-4xl font-mono text-warning-amber">
                       {formatNumber(totals.totalEURMTL, 2)}
                     </div>
                   </div>
                   <div className="text-right">
-                    <div className="text-sm font-mono text-steel-gray uppercase">ВСЕГО XLM</div>
+                    <div className="text-sm font-mono text-steel-gray uppercase">TOTAL XLM</div>
                     <div className="text-4xl font-mono text-warning-amber">
                       {formatNumber(totals.totalXLM, 7)}
                     </div>
@@ -907,9 +907,9 @@ export function FundStructureTable({ fundData, explorer, isLoading = false }: Fu
         {fundData.otherAccounts && fundData.otherAccounts.length > 0 && (
           <Card className="p-0 border-0 bg-card text-card-foreground overflow-hidden">
             <div className="bg-steel-gray/30 text-foreground p-6 border-l-4 border-steel-gray">
-              <h2 className="text-2xl font-mono uppercase tracking-wider">ПРОЧИЕ СЧЕТА</h2>
+              <h2 className="text-2xl font-mono uppercase tracking-wider">OTHER ACCOUNTS</h2>
               <p className="text-sm font-mono mt-2 text-steel-gray">
-                Не входят в общий итог фонда
+                Not included in fund grand total
               </p>
             </div>
 
@@ -920,23 +920,23 @@ export function FundStructureTable({ fundData, explorer, isLoading = false }: Fu
                   <TableHeader>
                     <TableRow className="border-steel-gray">
                       <TableHead className="text-foreground font-mono uppercase tracking-wider w-32 bg-background">
-                        ТОКЕН
+                        TOKEN
                       </TableHead>
                       <TableHead className="text-foreground font-mono uppercase tracking-wider w-40 bg-background">
-                        БАЛАНС
+                        BALANCE
                       </TableHead>
                       <TableHead className="text-foreground font-mono uppercase tracking-wider text-right w-32 bg-background">
                         <Tooltip>
                           <TooltipTrigger asChild>
                             <span className="cursor-help underline-offset-2 hover:underline">
-                              ЦЕНА (EURMTL)
+                              PRICE (EURMTL)
                             </span>
                           </TooltipTrigger>
                           <TooltipContent side="top" className="max-w-xs">
                             <div className="font-mono text-xs space-y-1">
-                              <div className="text-electric-cyan uppercase font-bold">ЦЕНА ЗА 1 ТОКЕН</div>
+                              <div className="text-electric-cyan uppercase font-bold">PRICE PER TOKEN</div>
                               <div className="text-steel-gray">
-                                Показывает цену обмена за одну единицу токена в EURMTL
+                                Exchange price for one token unit in EURMTL
                               </div>
                             </div>
                           </TooltipContent>
@@ -946,13 +946,13 @@ export function FundStructureTable({ fundData, explorer, isLoading = false }: Fu
                         <Tooltip>
                           <TooltipTrigger asChild>
                             <span className="cursor-help underline-offset-2 hover:underline">
-                              ЦЕНА (XLM)
+                              PRICE (XLM)
                             </span>
                           </TooltipTrigger>
                           <TooltipContent side="top" className="max-w-xs">
                             <div className="font-mono text-xs space-y-1">
-                              <div className="text-electric-cyan uppercase font-bold">ЦЕНА ЗА 1 ТОКЕН</div>
-                              <div className="text-steel-gray">Показывает цену обмена за одну единицу токена в XLM</div>
+                              <div className="text-electric-cyan uppercase font-bold">PRICE PER TOKEN</div>
+                              <div className="text-steel-gray">Exchange price for one token unit in XLM</div>
                             </div>
                           </TooltipContent>
                         </Tooltip>
@@ -961,14 +961,14 @@ export function FundStructureTable({ fundData, explorer, isLoading = false }: Fu
                         <Tooltip>
                           <TooltipTrigger asChild>
                             <span className="cursor-help underline-offset-2 hover:underline">
-                              СТОИМОСТЬ (EURMTL)
+                              VALUE (EURMTL)
                             </span>
                           </TooltipTrigger>
                           <TooltipContent side="top" className="max-w-xs">
                             <div className="font-mono text-xs space-y-1">
-                              <div className="text-electric-cyan uppercase font-bold">СТОИМОСТЬ ВСЕГО БАЛАНСА</div>
+                              <div className="text-electric-cyan uppercase font-bold">TOTAL BALANCE VALUE</div>
                               <div className="text-steel-gray">
-                                Показывает стоимость продажи всего баланса токена в EURMTL
+                                Sale value of the full token balance in EURMTL
                               </div>
                             </div>
                           </TooltipContent>
@@ -978,14 +978,14 @@ export function FundStructureTable({ fundData, explorer, isLoading = false }: Fu
                         <Tooltip>
                           <TooltipTrigger asChild>
                             <span className="cursor-help underline-offset-2 hover:underline">
-                              СТОИМОСТЬ (XLM)
+                              VALUE (XLM)
                             </span>
                           </TooltipTrigger>
                           <TooltipContent side="top" className="max-w-xs">
                             <div className="font-mono text-xs space-y-1">
-                              <div className="text-electric-cyan uppercase font-bold">СТОИМОСТЬ ВСЕГО БАЛАНСА</div>
+                              <div className="text-electric-cyan uppercase font-bold">TOTAL BALANCE VALUE</div>
                               <div className="text-steel-gray">
-                                Показывает стоимость продажи всего баланса токена в XLM
+                                Sale value of the full token balance in XLM
                               </div>
                             </div>
                           </TooltipContent>

--- a/apps/stat.mtlf.me/src/components/portfolio/fund-summary-metrics.test.tsx
+++ b/apps/stat.mtlf.me/src/components/portfolio/fund-summary-metrics.test.tsx
@@ -17,8 +17,8 @@ describe("FundSummaryMetrics", () => {
         />,
       );
 
-      expect(screen.getByText("⏳ ЗАГРУЗКА МЕТРИК...")).toBeInTheDocument();
-      expect(screen.getByText("Получение суммарных данных фонда...")).toBeInTheDocument();
+      expect(screen.getByText("⏳ LOADING METRICS...")).toBeInTheDocument();
+      expect(screen.getByText("Fetching aggregated fund data...")).toBeInTheDocument();
     });
   });
 
@@ -34,18 +34,14 @@ describe("FundSummaryMetrics", () => {
         />,
       );
 
-      expect(screen.getByText("ИТОГО ПО ФОНДУ")).toBeInTheDocument();
-      expect(
-        screen.getByText("Цена за 1 токен × Баланс"),
-      ).toBeInTheDocument();
+      expect(screen.getByText("FUND TOTALS")).toBeInTheDocument();
+      expect(screen.getByText("Price per token × balance")).toBeInTheDocument();
 
-      // Check for section labels
-      expect(screen.getByText("ИТОГО EURMTL")).toBeInTheDocument();
-      expect(screen.getByText("ИТОГО XLM")).toBeInTheDocument();
-      expect(screen.getByText("СЧЕТОВ")).toBeInTheDocument();
-      expect(screen.getByText("ТОКЕНОВ")).toBeInTheDocument();
+      expect(screen.getByText("TOTAL EURMTL")).toBeInTheDocument();
+      expect(screen.getByText("TOTAL XLM")).toBeInTheDocument();
+      expect(screen.getByText("ACCOUNTS")).toBeInTheDocument();
+      expect(screen.getByText("TOKENS")).toBeInTheDocument();
 
-      // Check account and token counts (exact text match)
       const accountCountElements = screen.getAllByText("8");
       expect(accountCountElements.length).toBeGreaterThan(0);
 
@@ -64,7 +60,7 @@ describe("FundSummaryMetrics", () => {
         />,
       );
 
-      expect(screen.getByText("ИТОГО ПО ФОНДУ")).toBeInTheDocument();
+      expect(screen.getByText("FUND TOTALS")).toBeInTheDocument();
     });
 
     test("should use electric-cyan styling", () => {
@@ -98,10 +94,9 @@ describe("FundSummaryMetrics", () => {
         />,
       );
 
-      // Verify nominal section is removed
-      expect(screen.queryByText("НОМИНАЛЬНЫЙ ИТОГ")).not.toBeInTheDocument();
-      expect(screen.queryByText("НОМИНАЛ EURMTL")).not.toBeInTheDocument();
-      expect(screen.queryByText("НОМИНАЛ XLM")).not.toBeInTheDocument();
+      expect(screen.queryByText("NOMINAL TOTAL")).not.toBeInTheDocument();
+      expect(screen.queryByText("NOMINAL EURMTL")).not.toBeInTheDocument();
+      expect(screen.queryByText("NOMINAL XLM")).not.toBeInTheDocument();
     });
 
     test("should NOT display liquid totals section", () => {
@@ -115,10 +110,9 @@ describe("FundSummaryMetrics", () => {
         />,
       );
 
-      // Verify liquid section is removed
-      expect(screen.queryByText("ЛИКВИДНЫЙ ИТОГ")).not.toBeInTheDocument();
-      expect(screen.queryByText("ЛИКВИД EURMTL")).not.toBeInTheDocument();
-      expect(screen.queryByText("ЛИКВИД XLM")).not.toBeInTheDocument();
+      expect(screen.queryByText("LIQUID TOTAL")).not.toBeInTheDocument();
+      expect(screen.queryByText("LIQUID EURMTL")).not.toBeInTheDocument();
+      expect(screen.queryByText("LIQUID XLM")).not.toBeInTheDocument();
     });
 
     test("should NOT display slippage columns", () => {
@@ -132,9 +126,8 @@ describe("FundSummaryMetrics", () => {
         />,
       );
 
-      // Verify slippage columns are removed
-      expect(screen.queryByText("ПРОСКАЛЬЗЫВАНИЕ EURMTL")).not.toBeInTheDocument();
-      expect(screen.queryByText("ПРОСКАЛЬЗЫВАНИЕ XLM")).not.toBeInTheDocument();
+      expect(screen.queryByText("SLIPPAGE EURMTL")).not.toBeInTheDocument();
+      expect(screen.queryByText("SLIPPAGE XLM")).not.toBeInTheDocument();
     });
 
     test("should NOT mention slippage in description", () => {
@@ -148,13 +141,8 @@ describe("FundSummaryMetrics", () => {
         />,
       );
 
-      // Verify the description no longer mentions slippage
-      expect(
-        screen.queryByText(/с учетом проскальзывания/i),
-      ).not.toBeInTheDocument();
-      expect(
-        screen.queryByText(/без учета проскальзывания/i),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByText(/with slippage/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/without slippage/i)).not.toBeInTheDocument();
     });
   });
 
@@ -170,7 +158,6 @@ describe("FundSummaryMetrics", () => {
         />,
       );
 
-      // Find the grid
       const grid = container.querySelector(".grid");
       expect(grid).toBeDefined();
 
@@ -192,11 +179,11 @@ describe("FundSummaryMetrics", () => {
       );
 
       const uppercaseElements = [
-        "ИТОГО ПО ФОНДУ",
-        "ИТОГО EURMTL",
-        "ИТОГО XLM",
-        "СЧЕТОВ",
-        "ТОКЕНОВ",
+        "FUND TOTALS",
+        "TOTAL EURMTL",
+        "TOTAL XLM",
+        "ACCOUNTS",
+        "TOKENS",
       ];
 
       for (const text of uppercaseElements) {
@@ -230,7 +217,6 @@ describe("FundSummaryMetrics", () => {
         />,
       );
 
-      // Card component should have border-0 class (zero border)
       const cards = container.querySelectorAll(".border-0");
       expect(cards.length).toBeGreaterThan(0);
     });
@@ -248,7 +234,7 @@ describe("FundSummaryMetrics", () => {
         />,
       );
 
-      expect(screen.getByText("ИТОГО ПО ФОНДУ")).toBeInTheDocument();
+      expect(screen.getByText("FUND TOTALS")).toBeInTheDocument();
     });
 
     test("should default isLoading to false when not provided", () => {
@@ -261,9 +247,8 @@ describe("FundSummaryMetrics", () => {
         />,
       );
 
-      // Should show content, not loading state
-      expect(screen.queryByText("⏳ ЗАГРУЗКА МЕТРИК...")).not.toBeInTheDocument();
-      expect(screen.getByText("ИТОГО ПО ФОНДУ")).toBeInTheDocument();
+      expect(screen.queryByText("⏳ LOADING METRICS...")).not.toBeInTheDocument();
+      expect(screen.getByText("FUND TOTALS")).toBeInTheDocument();
     });
   });
 });

--- a/apps/stat.mtlf.me/src/components/portfolio/fund-summary-metrics.tsx
+++ b/apps/stat.mtlf.me/src/components/portfolio/fund-summary-metrics.tsx
@@ -23,8 +23,8 @@ export function FundSummaryMetrics({
     return (
       <Card className="p-8 border-0 bg-card text-card-foreground">
         <div className="text-center">
-          <div className="text-2xl text-cyber-green mb-4">⏳ ЗАГРУЗКА МЕТРИК...</div>
-          <div className="text-steel-gray">Получение суммарных данных фонда...</div>
+          <div className="text-2xl text-cyber-green mb-4">⏳ LOADING METRICS...</div>
+          <div className="text-steel-gray">Fetching aggregated fund data...</div>
         </div>
       </Card>
     );
@@ -35,16 +35,16 @@ export function FundSummaryMetrics({
       <div className="bg-electric-cyan/10 border-l-4 border-electric-cyan p-6">
         <div className="mb-4">
           <h3 className="text-xl font-mono uppercase tracking-wider text-foreground">
-            ИТОГО ПО ФОНДУ
+            FUND TOTALS
           </h3>
           <p className="text-xs font-mono text-steel-gray uppercase mt-1">
-            Цена за 1 токен × Баланс
+            Price per token × balance
           </p>
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-8">
           <div className="space-y-2 min-w-0">
             <div className="text-sm font-mono text-steel-gray uppercase tracking-wider">
-              ИТОГО EURMTL
+              TOTAL EURMTL
             </div>
             <div className="text-4xl font-mono text-electric-cyan break-all">
               <TruncatedNumber
@@ -57,7 +57,7 @@ export function FundSummaryMetrics({
           </div>
           <div className="space-y-2 min-w-0">
             <div className="text-sm font-mono text-steel-gray uppercase tracking-wider">
-              ИТОГО XLM
+              TOTAL XLM
             </div>
             <div className="text-4xl font-mono text-electric-cyan break-all">
               <TruncatedNumber
@@ -70,7 +70,7 @@ export function FundSummaryMetrics({
           </div>
           <div className="space-y-2 min-w-0">
             <div className="text-sm font-mono text-steel-gray uppercase tracking-wider">
-              СЧЕТОВ
+              ACCOUNTS
             </div>
             <div className="text-3xl font-mono text-steel-gray">
               {accountCount}
@@ -78,7 +78,7 @@ export function FundSummaryMetrics({
           </div>
           <div className="space-y-2 min-w-0">
             <div className="text-sm font-mono text-steel-gray uppercase tracking-wider">
-              ТОКЕНОВ
+              TOKENS
             </div>
             <div className="text-3xl font-mono text-steel-gray">
               {tokenCount}

--- a/apps/stat.mtlf.me/src/components/portfolio/portfolio-demo.tsx
+++ b/apps/stat.mtlf.me/src/components/portfolio/portfolio-demo.tsx
@@ -72,7 +72,7 @@ export function PortfolioDemo() {
                 value={snapshot.date}
                 className="font-mono text-sm cursor-pointer hover:bg-steel-gray/20"
               >
-                {new Date(snapshot.date).toLocaleDateString("ru-RU", {
+                {new Date(snapshot.date).toLocaleDateString("en-US", {
                   year: "numeric",
                   month: "long",
                   day: "numeric",
@@ -86,7 +86,7 @@ export function PortfolioDemo() {
       {(error ?? snapshotsError) != null && (
         <div className="border border-red-500 bg-red-500/10 p-6">
           <h2 className="font-mono text-red-500 uppercase tracking-wider text-xl mb-2">
-            ОШИБКА ЗАГРУЗКИ
+            LOAD ERROR
           </h2>
           <p className="font-mono text-red-400">{error ?? snapshotsError}</p>
         </div>

--- a/apps/stat.mtlf.me/src/components/ui/truncated-number.tsx
+++ b/apps/stat.mtlf.me/src/components/ui/truncated-number.tsx
@@ -83,20 +83,20 @@ export function TruncatedNumber({
             {copied
               ? (
                 <div className="text-cyber-green uppercase text-sm font-bold">
-                  ✓ СКОПИРОВАНО
+                  ✓ COPIED
                 </div>
               )
               : (
                 <>
                   <div className="text-electric-cyan uppercase text-xs font-bold border-b border-electric-cyan/30 pb-1">
-                    ПОЛНОЕ ЗНАЧЕНИЕ
+                    FULL VALUE
                   </div>
                   <div className="text-foreground text-sm break-all">
                     {fullDisplay}
                     {suffix}
                   </div>
                   <div className="text-steel-gray text-[10px] uppercase mt-2 pt-2 border-t border-steel-gray/30">
-                    Нажмите для копирования
+                    Click to copy
                   </div>
                 </>
               )}

--- a/apps/stat.mtlf.me/src/lib/fuzzy.test.ts
+++ b/apps/stat.mtlf.me/src/lib/fuzzy.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { fuzzyScore } from "./fuzzy";
+
+describe("fuzzyScore", () => {
+  test("empty query returns 1 (show-everything contract)", () => {
+    expect(fuzzyScore("", "anything")).toBe(1);
+    expect(fuzzyScore("", "")).toBe(1);
+  });
+
+  test("non-subsequence returns 0", () => {
+    expect(fuzzyScore("xyz", "abcdef")).toBe(0);
+    expect(fuzzyScore("abz", "abc")).toBe(0);
+  });
+
+  test("partial match where last query char missing returns 0", () => {
+    expect(fuzzyScore("abcd", "abc")).toBe(0);
+  });
+
+  test("is case-insensitive", () => {
+    expect(fuzzyScore("ABC", "abcdef")).toBeGreaterThan(0);
+    expect(fuzzyScore("abc", "ABCDEF")).toBe(fuzzyScore("ABC", "abcdef"));
+  });
+
+  test("contiguous match scores higher than scattered match", () => {
+    expect(fuzzyScore("abc", "abc")).toBeGreaterThan(fuzzyScore("abc", "axbxc"));
+  });
+
+  test("non-empty query into empty text returns 0", () => {
+    expect(fuzzyScore("a", "")).toBe(0);
+  });
+});

--- a/apps/stat.mtlf.me/src/lib/fuzzy.ts
+++ b/apps/stat.mtlf.me/src/lib/fuzzy.ts
@@ -1,0 +1,19 @@
+export const fuzzyScore = (query: string, text: string): number => {
+  if (query === "") return 1;
+  const q = query.toLowerCase();
+  const t = text.toLowerCase();
+  let qi = 0;
+  let score = 0;
+  let streak = 0;
+  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
+    if (t[ti] === q[qi]) {
+      streak++;
+      score += 1 + streak;
+      qi++;
+    } else {
+      streak = 0;
+    }
+  }
+  if (qi < q.length) return 0;
+  return score / (t.length + q.length);
+};

--- a/apps/stat.mtlf.me/src/lib/stellar/fund-structure-service.ts
+++ b/apps/stat.mtlf.me/src/lib/stellar/fund-structure-service.ts
@@ -65,26 +65,26 @@ const FUND_ACCOUNTS_RAW = [
     id: "GACKTN5DAZGWXRWB2WLM6OPBDHAMT6SJNGLJZPQMEZBUR4JUGBX2UK7V",
     name: "MAIN ISSUER",
     type: "issuer",
-    description: "Основной эмитент токенов фонда",
+    description: "Main fund token issuer",
   },
   // Subfonds
   {
     id: "GAQ5ERJVI6IW5UVNPEVXUUVMXH3GCDHJ4BJAXMAAKPR5VBWWAUOMABIZ",
     name: "MABIZ",
     type: "subfond",
-    description: "Сабфонд малого и среднего бизнеса",
+    description: "Small and medium business subfund",
   },
   {
     id: "GCOJHUKGHI6IATN7AIEK4PSNBPXIAIZ7KB2AWTTUCNIAYVPUB2DMCITY",
     name: "CITY",
     type: "subfond",
-    description: "Сабфонд городской инфраструктуры",
+    description: "Urban infrastructure subfund",
   },
   {
     id: "GAEZHXMFRW2MWLWCXSBNZNUSE6SN3ODZDDOMPFH3JPMJXN4DKBPMDEFI",
     name: "DEFI",
     type: "subfond",
-    description: "Сабфонд децентрализованных финансов",
+    description: "Decentralized finance subfund",
   },
   // Mutuals
   {
@@ -104,26 +104,26 @@ const FUND_ACCOUNTS_RAW = [
     id: "GBSCMGJCE4DLQ6TYRNUMXUZZUXGZBM4BXVZUIHBBL5CSRRW2GWEHUADM",
     name: "ADMIN",
     type: "operational",
-    description: "Операционный счёт администрирования",
+    description: "Administration operating account",
   },
   // Others (not included in fund totals)
   {
     id: "GA7I6SGUHQ26ARNCD376WXV5WSE7VJRX6OEFNFCEGRLFGZWQIV73LABR",
     name: "LABR",
     type: "other",
-    description: "Трудовые ресурсы (не входит в общий счёт фонда)",
+    description: "Labor resources (not included in fund total)",
   },
   {
     id: "GCR5J3NU2NNG2UKDQ5XSZVX7I6TDLB3LEN2HFUR2EPJUMNWCUL62MTLM",
     name: "MTLM",
     type: "other",
-    description: "Montelibero Meta (не входит в общий счёт фонда)",
+    description: "Montelibero Meta (not included in fund total)",
   },
   {
     id: "GDRLJC6EOKRR3BPKWGJPGI5GUN4GZFZRWQFDG3RJNZJEIBYA7B3EPROG",
     name: "PROGRAMMERS GUILD",
     type: "other",
-    description: "Гильдия программистов (не входит в общий счёт фонда)",
+    description: "Programmers Guild (not included in fund total)",
   },
 ] as const;
 


### PR DESCRIPTION
## Summary
- Fuzzy search + LIST/CARDS toggle on fund indicators (default LIST)
- Pie chart now shows I3 total and a DETAILS link; legend centered
- Removed Fund Details from homepage header; relocated back link on /fund
- All Russian UI text translated to English

## Test plan
- [x] `bun test` (82 pass / 1 skip)
- [x] `bun run build`
- [x] Manual smoke test: dashboard, search filter, view toggle, /fund page

🤖 Generated with [Claude Code](https://claude.com/claude-code)