### PR TITLE
fix(stat.mtlf.me): indicator search by ID, table columns, pie palette

### DIFF
--- a/apps/stat.mtlf.me/app/globals.css
+++ b/apps/stat.mtlf.me/app/globals.css
@@ -29,7 +29,7 @@
   --chart-1: #6366f1;         /* Indigo */
   --chart-2: #3b82f6;         /* Blue */
   --chart-3: #f59e0b;         /* Amber */
-  --chart-4: #8b5cf6;         /* Purple */
+  --chart-4: #f97316;         /* Orange */
   --chart-5: #ec4899;         /* Pink */
   --chart-6: #10b981;         /* Emerald */
 }
@@ -58,7 +58,7 @@
   --chart-1: #a78bfa;         /* Bright purple */
   --chart-2: #60a5fa;         /* Bright blue */
   --chart-3: #fbbf24;         /* Golden amber */
-  --chart-4: #c084fc;         /* Light violet */
+  --chart-4: #fb923c;         /* Bright orange */
   --chart-5: #f472b6;         /* Pink */
   --chart-6: #34d399;         /* Bright emerald */
 }
@@ -94,4 +94,14 @@ body {
   background: var(--background);
   color: var(--foreground);
   font-family: var(--font-mono); /* Monospace by default for terminal aesthetic */
+}
+
+html {
+  scrollbar-gutter: stable;
+}
+
+.recharts-wrapper :focus,
+.recharts-sector:focus,
+.recharts-pie-sector path:focus {
+  outline: none;
 }

--- a/apps/stat.mtlf.me/app/globals.css
+++ b/apps/stat.mtlf.me/app/globals.css
@@ -25,6 +25,13 @@
   --ring: #3b82f6;
   --card: #ffffff;
   --card-foreground: #0a0a0a;
+
+  --chart-1: #6366f1;         /* Indigo */
+  --chart-2: #3b82f6;         /* Blue */
+  --chart-3: #f59e0b;         /* Amber */
+  --chart-4: #8b5cf6;         /* Purple */
+  --chart-5: #ec4899;         /* Pink */
+  --chart-6: #10b981;         /* Emerald */
 }
 
 .dark {
@@ -47,6 +54,13 @@
   --ring: #818cf8;
   --card: #1a1229;
   --card-foreground: #e0d7ff;
+
+  --chart-1: #a78bfa;         /* Bright purple */
+  --chart-2: #60a5fa;         /* Bright blue */
+  --chart-3: #fbbf24;         /* Golden amber */
+  --chart-4: #c084fc;         /* Light violet */
+  --chart-5: #f472b6;         /* Pink */
+  --chart-6: #34d399;         /* Bright emerald */
 }
 
 @theme inline {

--- a/apps/stat.mtlf.me/src/components/dashboard/indicator-card.tsx
+++ b/apps/stat.mtlf.me/src/components/dashboard/indicator-card.tsx
@@ -16,6 +16,9 @@ const PERIOD_LABEL: Record<Range, string> = {
   all: "ALL",
 };
 
+export const INDICATOR_ROW_GRID =
+  "grid grid-cols-[3rem_minmax(0,1fr)_minmax(7rem,auto)] sm:grid-cols-[3rem_minmax(0,1fr)_minmax(7rem,auto)_repeat(3,minmax(4.5rem,auto))] items-center gap-x-3";
+
 const toNum = (raw: string): number => {
   const n = parseFloat(raw);
   return Number.isFinite(n) ? n : 0;
@@ -90,7 +93,9 @@ export function IndicatorRow({ indicator }: IndicatorCardProps) {
   const { value, unit } = formatIndicatorValue(indicator);
 
   return (
-    <div className="grid grid-cols-[3rem_1fr_auto_auto] items-center gap-3 border border-steel-gray/40 bg-card px-3 py-2 hover:border-electric-cyan transition-colors">
+    <div
+      className={`${INDICATOR_ROW_GRID} border border-steel-gray/40 bg-card px-3 py-2 hover:border-electric-cyan transition-colors`}
+    >
       <span className="font-mono text-[10px] uppercase tracking-widest text-steel-gray">
         I{indicator.id}
       </span>
@@ -100,23 +105,37 @@ export function IndicatorRow({ indicator }: IndicatorCardProps) {
       >
         {indicator.name}
       </span>
-      <span className="font-mono text-sm tabular-nums whitespace-nowrap">
+      <span className="font-mono text-sm tabular-nums whitespace-nowrap text-right">
         <span className="text-cyber-green">{value}</span>
         <span className="ml-1 text-[10px] uppercase text-steel-gray">{unit}</span>
       </span>
-      <span className="hidden sm:flex items-center gap-3 font-mono text-[11px] tabular-nums whitespace-nowrap">
-        {PERIODS.map((p) => {
-          const change = indicator.changes?.[p];
-          return (
-            <span key={p} className="flex items-baseline gap-1">
-              <span className="uppercase tracking-wider text-steel-gray">{PERIOD_LABEL[p]}</span>
-              <span className={change !== undefined ? changeColor(change.pct) : "text-steel-gray/60"}>
-                {change !== undefined ? `${formatSignedPct(change.pct)}%` : "—"}
-              </span>
-            </span>
-          );
-        })}
-      </span>
+      {PERIODS.map((p) => {
+        const change = indicator.changes?.[p];
+        const colorClass = change !== undefined ? changeColor(change.pct) : "text-steel-gray/60";
+        return (
+          <span
+            key={p}
+            className={`hidden sm:block font-mono text-[11px] tabular-nums whitespace-nowrap text-right ${colorClass}`}
+          >
+            {change !== undefined ? `${formatSignedPct(change.pct)}%` : "—"}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+export function IndicatorRowHeader() {
+  return (
+    <div className={`${INDICATOR_ROW_GRID} px-3 pb-1 font-mono text-[10px] uppercase tracking-widest text-steel-gray`}>
+      <span>ID</span>
+      <span>NAME</span>
+      <span className="text-right">VALUE</span>
+      {PERIODS.map((p) => (
+        <span key={p} className="hidden sm:block text-right">
+          {PERIOD_LABEL[p]}
+        </span>
+      ))}
     </div>
   );
 }

--- a/apps/stat.mtlf.me/src/components/dashboard/indicators-grid.test.tsx
+++ b/apps/stat.mtlf.me/src/components/dashboard/indicators-grid.test.tsx
@@ -111,4 +111,59 @@ describe("IndicatorsGrid", () => {
     expect(screen.getByRole("button", { name: "CARDS" }).getAttribute("aria-pressed")).toBe("true");
     expect(screen.getByRole("button", { name: "LIST" }).getAttribute("aria-pressed")).toBe("false");
   });
+
+  test("ID search \"I30\" filters to id=30 row only", () => {
+    const items: Indicator[] = [
+      make(26, "EURMTL Volume", "Volume metric"),
+      make(30, "Price Book Ratio", "Book ratio metric"),
+    ];
+    render(<IndicatorsGrid data={items} isLoading={false} error={null} />);
+    fireEvent.change(screen.getByLabelText("Search indicators"), { target: { value: "I30" } });
+    expect(screen.getByText("Price Book Ratio")).toBeDefined();
+    expect(screen.queryByText("EURMTL Volume")).toBeNull();
+  });
+
+  test("ID prefix \"I3\" includes id=30 but excludes id=130", () => {
+    const items: Indicator[] = [
+      make(30, "Three", ""),
+      make(130, "OneThirty", ""),
+    ];
+    render(<IndicatorsGrid data={items} isLoading={false} error={null} />);
+    fireEvent.change(screen.getByLabelText("Search indicators"), { target: { value: "I3" } });
+    expect(screen.getByText("Three")).toBeDefined();
+    expect(screen.queryByText("OneThirty")).toBeNull();
+  });
+
+  test("list view ready: header row is rendered", () => {
+    render(<IndicatorsGrid data={sample} isLoading={false} error={null} />);
+    expect(screen.getByText("ID")).toBeDefined();
+    expect(screen.getByText("NAME")).toBeDefined();
+    expect(screen.getByText("VALUE")).toBeDefined();
+    expect(screen.getByText("30D")).toBeDefined();
+  });
+
+  test("list view loading: header row is rendered", () => {
+    render(<IndicatorsGrid data={[]} isLoading={true} error={null} />);
+    expect(screen.getByText("ID")).toBeDefined();
+    expect(screen.getByText("NAME")).toBeDefined();
+  });
+
+  test("cards view ready: header row is NOT rendered", () => {
+    render(<IndicatorsGrid data={sample} isLoading={false} error={null} />);
+    fireEvent.click(screen.getByRole("button", { name: "CARDS" }));
+    expect(screen.queryByText("ID")).toBeNull();
+    expect(screen.queryByText("NAME")).toBeNull();
+  });
+
+  test("empty state: header row is NOT rendered", () => {
+    render(<IndicatorsGrid data={[]} isLoading={false} error={null} />);
+    expect(screen.queryByText("ID")).toBeNull();
+    expect(screen.queryByText("NAME")).toBeNull();
+  });
+
+  test("error state: header row is NOT rendered", () => {
+    render(<IndicatorsGrid data={[]} isLoading={false} error="boom" />);
+    expect(screen.queryByText("ID")).toBeNull();
+    expect(screen.queryByText("NAME")).toBeNull();
+  });
 });

--- a/apps/stat.mtlf.me/src/components/dashboard/indicators-grid.tsx
+++ b/apps/stat.mtlf.me/src/components/dashboard/indicators-grid.tsx
@@ -4,7 +4,7 @@ import { scoreIndicator } from "@/lib/fuzzy";
 import type { Indicator } from "@/lib/api/types";
 import { cn } from "@/lib/utils";
 import { LayoutGrid, List, Search } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useDeferredValue, useMemo, useState } from "react";
 import { IndicatorCard, IndicatorRow, IndicatorRowHeader } from "./indicator-card";
 
 type ViewMode = "list" | "cards";
@@ -17,17 +17,18 @@ interface IndicatorsGridProps {
 
 export function IndicatorsGrid({ data, isLoading, error }: IndicatorsGridProps) {
   const [query, setQuery] = useState("");
+  const deferredQuery = useDeferredValue(query);
   const [view, setView] = useState<ViewMode>("list");
 
   const filtered = useMemo(() => {
-    const q = query.trim();
+    const q = deferredQuery.trim();
     if (q === "") return data;
     return data
       .map((indicator) => ({ indicator, score: scoreIndicator(q, indicator) }))
       .filter((entry) => entry.score > 0)
       .sort((a, b) => b.score - a.score)
       .map((entry) => entry.indicator);
-  }, [data, query]);
+  }, [data, deferredQuery]);
 
   const state: "error" | "loading" | "empty" | "no-matches" | "ready" = error !== null
     ? "error"
@@ -40,7 +41,7 @@ export function IndicatorsGrid({ data, isLoading, error }: IndicatorsGridProps) 
     : "ready";
 
   return (
-    <section className="border border-cyber-green bg-background p-6">
+    <section className="border border-cyber-green bg-background p-6 min-h-[640px]">
       <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
         <h2 className="font-mono text-xl uppercase tracking-wider text-cyber-green">
           FUND INDICATORS

--- a/apps/stat.mtlf.me/src/components/dashboard/indicators-grid.tsx
+++ b/apps/stat.mtlf.me/src/components/dashboard/indicators-grid.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { fuzzyScore } from "@/lib/fuzzy";
+import { scoreIndicator } from "@/lib/fuzzy";
 import type { Indicator } from "@/lib/api/types";
 import { cn } from "@/lib/utils";
 import { LayoutGrid, List, Search } from "lucide-react";
 import { useMemo, useState } from "react";
-import { IndicatorCard, IndicatorRow } from "./indicator-card";
+import { IndicatorCard, IndicatorRow, IndicatorRowHeader } from "./indicator-card";
 
 type ViewMode = "list" | "cards";
 
@@ -14,12 +14,6 @@ interface IndicatorsGridProps {
   isLoading: boolean;
   error: string | null;
 }
-
-const scoreIndicator = (query: string, indicator: Indicator): number => {
-  const nameScore = fuzzyScore(query, indicator.name);
-  const descScore = fuzzyScore(query, indicator.description);
-  return Math.max(nameScore * 1.5, descScore);
-};
 
 export function IndicatorsGrid({ data, isLoading, error }: IndicatorsGridProps) {
   const [query, setQuery] = useState("");
@@ -68,7 +62,7 @@ export function IndicatorsGrid({ data, isLoading, error }: IndicatorsGridProps) 
           type="text"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          placeholder="SEARCH INDICATORS BY NAME OR DESCRIPTION"
+          placeholder="SEARCH BY ID (E.G. I30), NAME OR DESCRIPTION"
           className="flex-1 bg-transparent font-mono text-xs uppercase tracking-wider text-foreground placeholder:text-steel-gray focus:outline-none"
           aria-label="Search indicators"
         />
@@ -90,17 +84,20 @@ export function IndicatorsGrid({ data, isLoading, error }: IndicatorsGridProps) 
       )}
 
       {state === "loading" && (
-        <IndicatorListLayout view={view}>
-          {Array.from({ length: view === "cards" ? 8 : 6 }).map((_, i) => (
-            <div
-              key={i}
-              className={cn(
-                "border border-steel-gray/30 bg-steel-gray/10 animate-pulse",
-                view === "cards" ? "h-44" : "h-10",
-              )}
-            />
-          ))}
-        </IndicatorListLayout>
+        <>
+          {view === "list" && <IndicatorRowHeader />}
+          <IndicatorListLayout view={view}>
+            {Array.from({ length: view === "cards" ? 8 : 6 }).map((_, i) => (
+              <div
+                key={i}
+                className={cn(
+                  "border border-steel-gray/30 bg-steel-gray/10 animate-pulse",
+                  view === "cards" ? "h-44" : "h-10",
+                )}
+              />
+            ))}
+          </IndicatorListLayout>
+        </>
       )}
 
       {state === "empty" && (
@@ -112,13 +109,16 @@ export function IndicatorsGrid({ data, isLoading, error }: IndicatorsGridProps) 
       )}
 
       {state === "ready" && (
-        <IndicatorListLayout view={view}>
-          {filtered.map((indicator) =>
-            view === "cards"
-              ? <IndicatorCard key={indicator.id} indicator={indicator} />
-              : <IndicatorRow key={indicator.id} indicator={indicator} />
-          )}
-        </IndicatorListLayout>
+        <>
+          {view === "list" && <IndicatorRowHeader />}
+          <IndicatorListLayout view={view}>
+            {filtered.map((indicator) =>
+              view === "cards"
+                ? <IndicatorCard key={indicator.id} indicator={indicator} />
+                : <IndicatorRow key={indicator.id} indicator={indicator} />
+            )}
+          </IndicatorListLayout>
+        </>
       )}
     </section>
   );

--- a/apps/stat.mtlf.me/src/components/dashboard/subfund-pie-chart.tsx
+++ b/apps/stat.mtlf.me/src/components/dashboard/subfund-pie-chart.tsx
@@ -7,10 +7,12 @@ import Link from "next/link";
 import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip, type TooltipProps } from "recharts";
 
 const PALETTE = [
-  "var(--cyber-green)",
-  "var(--electric-cyan)",
-  "var(--warning-amber)",
-  "var(--secondary)",
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+  "var(--chart-6)",
 ];
 
 interface SubfundPieChartProps {

--- a/apps/stat.mtlf.me/src/components/dashboard/subfund-pie-chart.tsx
+++ b/apps/stat.mtlf.me/src/components/dashboard/subfund-pie-chart.tsx
@@ -95,6 +95,8 @@ export function SubfundPieChart({ slices, date, totalValue, totalUnit }: Subfund
               isAnimationActive={false}
               stroke="var(--background)"
               strokeWidth={2}
+              rootTabIndex={-1}
+              tabIndex={-1}
             >
               {enriched.map((_, i) => <Cell key={i} fill={PALETTE[i % PALETTE.length]} />)}
             </Pie>

--- a/apps/stat.mtlf.me/src/lib/fuzzy.test.ts
+++ b/apps/stat.mtlf.me/src/lib/fuzzy.test.ts
@@ -38,13 +38,26 @@ describe("scoreIndicator", () => {
     expect(scoreIndicator("I30", i30)).toBeGreaterThan(0);
   });
 
-  test("\"I30\" prefers id=30 over id=26", () => {
+  test("\"I30\" exact code outranks unrelated indicator", () => {
     expect(scoreIndicator("I30", i30)).toBeGreaterThan(scoreIndicator("I30", i26));
   });
 
+  test("\"I3\" does NOT match id=30 (would otherwise be ambiguous)", () => {
+    expect(scoreIndicator("I3", { id: 3, name: "Foo", description: "" })).toBeGreaterThan(0);
+    expect(scoreIndicator("I3", { id: 30, name: "Foo", description: "" })).toBeGreaterThan(0);
+    expect(scoreIndicator("I3", { id: 3, name: "Foo", description: "" }))
+      .toBeGreaterThanOrEqual(scoreIndicator("I3", { id: 30, name: "Foo", description: "" }));
+  });
+
+  test("\"I3\" prefix-matches I3, I30, I300 but not I130", () => {
+    const prefix = scoreIndicator("I3", { id: 30, name: "X", description: "" });
+    const nonPrefix = scoreIndicator("I3", { id: 130, name: "X", description: "" });
+    expect(prefix).toBeGreaterThan(0);
+    expect(nonPrefix).toBe(0);
+  });
+
   test("ID match outranks accidental letter matches", () => {
-    const noMatch = { id: 7, name: "EURMTL participants", description: "" };
-    expect(scoreIndicator("I7", { id: 7, name: noMatch.name, description: noMatch.description }))
+    expect(scoreIndicator("I7", { id: 7, name: "EURMTL participants", description: "" }))
       .toBeGreaterThan(scoreIndicator("I7", { id: 99, name: "Insurance index 7", description: "" }));
   });
 
@@ -58,5 +71,9 @@ describe("scoreIndicator", () => {
 
   test("empty query returns positive score (show-all contract)", () => {
     expect(scoreIndicator("", i30)).toBeGreaterThan(0);
+  });
+
+  test("whitespace-only query behaves like empty", () => {
+    expect(scoreIndicator("   ", i30)).toBeGreaterThan(0);
   });
 });

--- a/apps/stat.mtlf.me/src/lib/fuzzy.test.ts
+++ b/apps/stat.mtlf.me/src/lib/fuzzy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { fuzzyScore } from "./fuzzy";
+import { fuzzyScore, scoreIndicator } from "./fuzzy";
 
 describe("fuzzyScore", () => {
   test("empty query returns 1 (show-everything contract)", () => {
@@ -27,5 +27,36 @@ describe("fuzzyScore", () => {
 
   test("non-empty query into empty text returns 0", () => {
     expect(fuzzyScore("a", "")).toBe(0);
+  });
+});
+
+describe("scoreIndicator", () => {
+  const i30 = { id: 30, name: "Share Book Value", description: "Book value of fund" };
+  const i26 = { id: 26, name: "Insurance Reserve", description: "Reserve fund" };
+
+  test("\"I30\" matches indicator with id=30 even when name/desc lack '30'", () => {
+    expect(scoreIndicator("I30", i30)).toBeGreaterThan(0);
+  });
+
+  test("\"I30\" prefers id=30 over id=26", () => {
+    expect(scoreIndicator("I30", i30)).toBeGreaterThan(scoreIndicator("I30", i26));
+  });
+
+  test("ID match outranks accidental letter matches", () => {
+    const noMatch = { id: 7, name: "EURMTL participants", description: "" };
+    expect(scoreIndicator("I7", { id: 7, name: noMatch.name, description: noMatch.description }))
+      .toBeGreaterThan(scoreIndicator("I7", { id: 99, name: "Insurance index 7", description: "" }));
+  });
+
+  test("matches by name when query is descriptive", () => {
+    expect(scoreIndicator("share", i30)).toBeGreaterThan(0);
+  });
+
+  test("returns 0 when nothing matches", () => {
+    expect(scoreIndicator("zzz", i30)).toBe(0);
+  });
+
+  test("empty query returns positive score (show-all contract)", () => {
+    expect(scoreIndicator("", i30)).toBeGreaterThan(0);
   });
 });

--- a/apps/stat.mtlf.me/src/lib/fuzzy.ts
+++ b/apps/stat.mtlf.me/src/lib/fuzzy.ts
@@ -17,3 +17,17 @@ export const fuzzyScore = (query: string, text: string): number => {
   if (qi < q.length) return 0;
   return score / (t.length + q.length);
 };
+
+interface IndicatorSearchFields {
+  readonly id: number;
+  readonly name: string;
+  readonly description: string;
+}
+
+export const scoreIndicator = (query: string, indicator: IndicatorSearchFields): number => {
+  const code = `I${indicator.id}`;
+  const idScore = fuzzyScore(query, code);
+  const nameScore = fuzzyScore(query, indicator.name);
+  const descScore = fuzzyScore(query, indicator.description);
+  return Math.max(idScore * 2, nameScore * 1.5, descScore);
+};

--- a/apps/stat.mtlf.me/src/lib/fuzzy.ts
+++ b/apps/stat.mtlf.me/src/lib/fuzzy.ts
@@ -18,16 +18,26 @@ export const fuzzyScore = (query: string, text: string): number => {
   return score / (t.length + q.length);
 };
 
-interface IndicatorSearchFields {
+export interface IndicatorSearchFields {
   readonly id: number;
   readonly name: string;
   readonly description: string;
 }
 
+const codeMatchScore = (query: string, code: string): number => {
+  const q = query.toLowerCase();
+  const c = code.toLowerCase();
+  if (q === c) return 3;
+  if (c.startsWith(q)) return 2;
+  return 0;
+};
+
 export const scoreIndicator = (query: string, indicator: IndicatorSearchFields): number => {
+  const trimmed = query.trim();
+  if (trimmed === "") return fuzzyScore("", indicator.name);
   const code = `I${indicator.id}`;
-  const idScore = fuzzyScore(query, code);
-  const nameScore = fuzzyScore(query, indicator.name);
-  const descScore = fuzzyScore(query, indicator.description);
-  return Math.max(idScore * 2, nameScore * 1.5, descScore);
+  const idScore = codeMatchScore(trimmed, code);
+  const nameScore = fuzzyScore(trimmed, indicator.name);
+  const descScore = fuzzyScore(trimmed, indicator.description);
+  return Math.max(idScore, nameScore * 1.5, descScore);
 };


### PR DESCRIPTION
## Summary

Three fixes to the indicator dashboard on `stat.mtlf.me`:

- **Search now matches indicator ID code (e.g. `I30`)** — previously the fuzzy filter only saw `name` and `description`, so typing the visible code `I30` returned nothing while a single letter `I` returned random matches. Logic extracted to `scoreIndicator` in `src/lib/fuzzy.ts` with weighted boost so id matches outrank accidental letter hits.
- **Indicator list view: 30D / 90D / 365D as separate columns** — the previous layout crammed all three periods into one cell, so values didn't align between rows. Now each period gets its own right-aligned `tabular-nums` column, with a labelled header row (also rendered during loading to avoid layout shift).
- **Pie chart palette expanded from 4 → 6 colors** — added `--chart-1..6` CSS tokens for both light and dark themes; `MAIN ISSUER` and `ADMIN` no longer share colors with subfond slices.

## Test plan

- [x] `bun test` — 113/114 pass (1 pre-existing skip)
- [x] `bun lint` — clean
- [x] Dev server: pie chart renders all 6 slices with distinct colors
- [x] Dev server: search "I30" → finds `I30 PRICE/BOOK RATIO` (1/34 indicators)
- [x] Dev server: search "I26" → finds `I26 EURMTL 30d Volume`
- [x] Dev server: indicator table columns align across rows
- [ ] Verify dark mode pie chart on staging
- [ ] Verify mobile layout on real device

🤖 Generated with [Claude Code](https://claude.com/claude-code)