### PR TITLE
feat(stat.mtlf.me): reorder dashboard and add KEY/ALL indicator scope

### DIFF
--- a/apps/stat.mtlf.me/src/components/dashboard/dashboard-page.tsx
+++ b/apps/stat.mtlf.me/src/components/dashboard/dashboard-page.tsx
@@ -21,6 +21,10 @@ const KEY_INDICATORS: readonly { id: number; name: string }[] = [
 const KEY_IDS = KEY_INDICATORS.map((k) => k.id);
 const TOTAL_INDICATOR_ID = 3;
 
+const KEY_INDICATOR_IDS: readonly number[] = [
+  1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 15, 16, 17, 18, 22, 24, 27, 30, 40,
+];
+
 export function DashboardPage() {
   const { data: subfundData, isLoading: subfundLoading, error: subfundError } = useSubfundBalance();
   const { data: indicators, isLoading: indicatorsLoading, error: indicatorsError } = useIndicators();
@@ -52,6 +56,13 @@ export function DashboardPage() {
         )}
       </section>
 
+      <IndicatorsGrid
+        data={indicators}
+        keyIds={KEY_INDICATOR_IDS}
+        isLoading={indicatorsLoading}
+        error={indicatorsError}
+      />
+
       <section>
         <div className="mb-4 flex flex-wrap items-baseline justify-between gap-3">
           <h2 className="font-mono text-xl uppercase tracking-wider text-cyber-green">
@@ -72,12 +83,6 @@ export function DashboardPage() {
           ))}
         </div>
       </section>
-
-      <IndicatorsGrid
-        data={indicators}
-        isLoading={indicatorsLoading}
-        error={indicatorsError}
-      />
     </div>
   );
 }

--- a/apps/stat.mtlf.me/src/components/dashboard/indicators-grid.test.tsx
+++ b/apps/stat.mtlf.me/src/components/dashboard/indicators-grid.test.tsx
@@ -21,22 +21,24 @@ const sample: Indicator[] = [
   make(3, "DEFI Total Value", "DEFI subfund assets"),
 ];
 
+const ALL_KEY_IDS = [1, 2, 3];
+
 describe("IndicatorsGrid", () => {
   test("renders all indicators in default LIST view", () => {
-    render(<IndicatorsGrid data={sample} isLoading={false} error={null} />);
+    render(<IndicatorsGrid data={sample} keyIds={ALL_KEY_IDS} isLoading={false} error={null} />);
     expect(screen.getByText("Assets Value")).toBeDefined();
     expect(screen.getByText("Operating Balance")).toBeDefined();
     expect(screen.getByText("DEFI Total Value")).toBeDefined();
   });
 
   test("LIST is the default view (aria-pressed)", () => {
-    render(<IndicatorsGrid data={sample} isLoading={false} error={null} />);
+    render(<IndicatorsGrid data={sample} keyIds={ALL_KEY_IDS} isLoading={false} error={null} />);
     expect(screen.getByRole("button", { name: "LIST" }).getAttribute("aria-pressed")).toBe("true");
     expect(screen.getByRole("button", { name: "CARDS" }).getAttribute("aria-pressed")).toBe("false");
   });
 
   test("typing in search filters by name", () => {
-    render(<IndicatorsGrid data={sample} isLoading={false} error={null} />);
+    render(<IndicatorsGrid data={sample} keyIds={ALL_KEY_IDS} isLoading={false} error={null} />);
     fireEvent.change(screen.getByLabelText("Search indicators"), { target: { value: "defi" } });
     expect(screen.queryByText("Assets Value")).toBeNull();
     expect(screen.queryByText("Operating Balance")).toBeNull();
@@ -44,7 +46,7 @@ describe("IndicatorsGrid", () => {
   });
 
   test("typing in search filters by description", () => {
-    render(<IndicatorsGrid data={sample} isLoading={false} error={null} />);
+    render(<IndicatorsGrid data={sample} keyIds={ALL_KEY_IDS} isLoading={false} error={null} />);
     fireEvent.change(screen.getByLabelText("Search indicators"), { target: { value: "cash" } });
     expect(screen.queryByText("Assets Value")).toBeNull();
     expect(screen.getByText("Operating Balance")).toBeDefined();
@@ -55,14 +57,14 @@ describe("IndicatorsGrid", () => {
       make(10, "Foo Bar", "this contains DEFI in description"),
       make(11, "DEFI Subfund", "unrelated description"),
     ];
-    render(<IndicatorsGrid data={items} isLoading={false} error={null} />);
+    render(<IndicatorsGrid data={items} keyIds={[10, 11]} isLoading={false} error={null} />);
     fireEvent.change(screen.getByLabelText("Search indicators"), { target: { value: "defi" } });
     const rendered = screen.getAllByText(/DEFI Subfund|Foo Bar/);
     expect(rendered[0]?.textContent).toBe("DEFI Subfund");
   });
 
   test("empty/whitespace query shows full list", () => {
-    render(<IndicatorsGrid data={sample} isLoading={false} error={null} />);
+    render(<IndicatorsGrid data={sample} keyIds={ALL_KEY_IDS} isLoading={false} error={null} />);
     fireEvent.change(screen.getByLabelText("Search indicators"), { target: { value: "   " } });
     expect(screen.getByText("Assets Value")).toBeDefined();
     expect(screen.getByText("Operating Balance")).toBeDefined();
@@ -70,23 +72,23 @@ describe("IndicatorsGrid", () => {
   });
 
   test("shows NO MATCHES state for non-matching query", () => {
-    render(<IndicatorsGrid data={sample} isLoading={false} error={null} />);
+    render(<IndicatorsGrid data={sample} keyIds={ALL_KEY_IDS} isLoading={false} error={null} />);
     fireEvent.change(screen.getByLabelText("Search indicators"), { target: { value: "xyzzy" } });
     expect(screen.getByText(/NO MATCHES FOR/)).toBeDefined();
   });
 
   test("shows INDICATORS NOT YET COMPUTED when data is empty", () => {
-    render(<IndicatorsGrid data={[]} isLoading={false} error={null} />);
+    render(<IndicatorsGrid data={[]} keyIds={ALL_KEY_IDS} isLoading={false} error={null} />);
     expect(screen.getByText("INDICATORS NOT YET COMPUTED")).toBeDefined();
   });
 
   test("shows error state", () => {
-    render(<IndicatorsGrid data={[]} isLoading={false} error="boom" />);
+    render(<IndicatorsGrid data={[]} keyIds={ALL_KEY_IDS} isLoading={false} error="boom" />);
     expect(screen.getByText("ERROR: boom")).toBeDefined();
   });
 
   test("CLEAR button resets query and restores full list", () => {
-    render(<IndicatorsGrid data={sample} isLoading={false} error={null} />);
+    render(<IndicatorsGrid data={sample} keyIds={ALL_KEY_IDS} isLoading={false} error={null} />);
     fireEvent.change(screen.getByLabelText("Search indicators"), { target: { value: "defi" } });
     fireEvent.click(screen.getByRole("button", { name: "CLEAR" }));
     expect(screen.getByText("Assets Value")).toBeDefined();
@@ -95,18 +97,18 @@ describe("IndicatorsGrid", () => {
   });
 
   test("counter shows filtered/total when filtering reduces count", () => {
-    render(<IndicatorsGrid data={sample} isLoading={false} error={null} />);
+    render(<IndicatorsGrid data={sample} keyIds={ALL_KEY_IDS} isLoading={false} error={null} />);
     fireEvent.change(screen.getByLabelText("Search indicators"), { target: { value: "defi" } });
     expect(screen.getByText(/1 \/ 3 INDICATORS/)).toBeDefined();
   });
 
   test("counter shows just total when no filter applied", () => {
-    render(<IndicatorsGrid data={sample} isLoading={false} error={null} />);
+    render(<IndicatorsGrid data={sample} keyIds={ALL_KEY_IDS} isLoading={false} error={null} />);
     expect(screen.getByText("3 INDICATORS")).toBeDefined();
   });
 
   test("CARDS toggle switches view", () => {
-    render(<IndicatorsGrid data={sample} isLoading={false} error={null} />);
+    render(<IndicatorsGrid data={sample} keyIds={ALL_KEY_IDS} isLoading={false} error={null} />);
     fireEvent.click(screen.getByRole("button", { name: "CARDS" }));
     expect(screen.getByRole("button", { name: "CARDS" }).getAttribute("aria-pressed")).toBe("true");
     expect(screen.getByRole("button", { name: "LIST" }).getAttribute("aria-pressed")).toBe("false");
@@ -117,7 +119,7 @@ describe("IndicatorsGrid", () => {
       make(26, "EURMTL Volume", "Volume metric"),
       make(30, "Price Book Ratio", "Book ratio metric"),
     ];
-    render(<IndicatorsGrid data={items} isLoading={false} error={null} />);
+    render(<IndicatorsGrid data={items} keyIds={[26, 30]} isLoading={false} error={null} />);
     fireEvent.change(screen.getByLabelText("Search indicators"), { target: { value: "I30" } });
     expect(screen.getByText("Price Book Ratio")).toBeDefined();
     expect(screen.queryByText("EURMTL Volume")).toBeNull();
@@ -128,14 +130,14 @@ describe("IndicatorsGrid", () => {
       make(30, "Three", ""),
       make(130, "OneThirty", ""),
     ];
-    render(<IndicatorsGrid data={items} isLoading={false} error={null} />);
+    render(<IndicatorsGrid data={items} keyIds={[30, 130]} isLoading={false} error={null} />);
     fireEvent.change(screen.getByLabelText("Search indicators"), { target: { value: "I3" } });
     expect(screen.getByText("Three")).toBeDefined();
     expect(screen.queryByText("OneThirty")).toBeNull();
   });
 
   test("list view ready: header row is rendered", () => {
-    render(<IndicatorsGrid data={sample} isLoading={false} error={null} />);
+    render(<IndicatorsGrid data={sample} keyIds={ALL_KEY_IDS} isLoading={false} error={null} />);
     expect(screen.getByText("ID")).toBeDefined();
     expect(screen.getByText("NAME")).toBeDefined();
     expect(screen.getByText("VALUE")).toBeDefined();
@@ -143,27 +145,61 @@ describe("IndicatorsGrid", () => {
   });
 
   test("list view loading: header row is rendered", () => {
-    render(<IndicatorsGrid data={[]} isLoading={true} error={null} />);
+    render(<IndicatorsGrid data={[]} keyIds={ALL_KEY_IDS} isLoading={true} error={null} />);
     expect(screen.getByText("ID")).toBeDefined();
     expect(screen.getByText("NAME")).toBeDefined();
   });
 
   test("cards view ready: header row is NOT rendered", () => {
-    render(<IndicatorsGrid data={sample} isLoading={false} error={null} />);
+    render(<IndicatorsGrid data={sample} keyIds={ALL_KEY_IDS} isLoading={false} error={null} />);
     fireEvent.click(screen.getByRole("button", { name: "CARDS" }));
     expect(screen.queryByText("ID")).toBeNull();
     expect(screen.queryByText("NAME")).toBeNull();
   });
 
   test("empty state: header row is NOT rendered", () => {
-    render(<IndicatorsGrid data={[]} isLoading={false} error={null} />);
+    render(<IndicatorsGrid data={[]} keyIds={ALL_KEY_IDS} isLoading={false} error={null} />);
     expect(screen.queryByText("ID")).toBeNull();
     expect(screen.queryByText("NAME")).toBeNull();
   });
 
   test("error state: header row is NOT rendered", () => {
-    render(<IndicatorsGrid data={[]} isLoading={false} error="boom" />);
+    render(<IndicatorsGrid data={[]} keyIds={ALL_KEY_IDS} isLoading={false} error="boom" />);
     expect(screen.queryByText("ID")).toBeNull();
     expect(screen.queryByText("NAME")).toBeNull();
+  });
+
+  test("KEY scope is the default and shows only key indicators", () => {
+    render(<IndicatorsGrid data={sample} keyIds={[1, 3]} isLoading={false} error={null} />);
+    expect(screen.getByRole("button", { name: "KEY" }).getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByRole("button", { name: "ALL" }).getAttribute("aria-pressed")).toBe("false");
+    expect(screen.getByText("Assets Value")).toBeDefined();
+    expect(screen.queryByText("Operating Balance")).toBeNull();
+    expect(screen.getByText("DEFI Total Value")).toBeDefined();
+    expect(screen.getByText("2 INDICATORS")).toBeDefined();
+  });
+
+  test("ALL scope shows every indicator", () => {
+    render(<IndicatorsGrid data={sample} keyIds={[1]} isLoading={false} error={null} />);
+    fireEvent.click(screen.getByRole("button", { name: "ALL" }));
+    expect(screen.getByRole("button", { name: "ALL" }).getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByText("Assets Value")).toBeDefined();
+    expect(screen.getByText("Operating Balance")).toBeDefined();
+    expect(screen.getByText("DEFI Total Value")).toBeDefined();
+    expect(screen.getByText("3 INDICATORS")).toBeDefined();
+  });
+
+  test("KEY scope with no matching ids in data shows NO KEY INDICATORS AVAILABLE", () => {
+    render(<IndicatorsGrid data={sample} keyIds={[999]} isLoading={false} error={null} />);
+    expect(screen.getByText("NO KEY INDICATORS AVAILABLE")).toBeDefined();
+    expect(screen.queryByText("INDICATORS NOT YET COMPUTED")).toBeNull();
+  });
+
+  test("search is scoped to the active set", () => {
+    render(<IndicatorsGrid data={sample} keyIds={[1]} isLoading={false} error={null} />);
+    fireEvent.change(screen.getByLabelText("Search indicators"), { target: { value: "defi" } });
+    expect(screen.getByText(/NO MATCHES FOR/)).toBeDefined();
+    fireEvent.click(screen.getByRole("button", { name: "ALL" }));
+    expect(screen.getByText("DEFI Total Value")).toBeDefined();
   });
 });

--- a/apps/stat.mtlf.me/src/components/dashboard/indicators-grid.tsx
+++ b/apps/stat.mtlf.me/src/components/dashboard/indicators-grid.tsx
@@ -8,34 +8,45 @@ import { useDeferredValue, useMemo, useState } from "react";
 import { IndicatorCard, IndicatorRow, IndicatorRowHeader } from "./indicator-card";
 
 type ViewMode = "list" | "cards";
+type Scope = "key" | "all";
 
 interface IndicatorsGridProps {
   data: readonly Indicator[];
+  keyIds: readonly number[];
   isLoading: boolean;
   error: string | null;
 }
 
-export function IndicatorsGrid({ data, isLoading, error }: IndicatorsGridProps) {
+export function IndicatorsGrid({ data, keyIds, isLoading, error }: IndicatorsGridProps) {
   const [query, setQuery] = useState("");
   const deferredQuery = useDeferredValue(query);
   const [view, setView] = useState<ViewMode>("list");
+  const [scope, setScope] = useState<Scope>("key");
+
+  const scoped = useMemo(() => {
+    if (scope === "all") return data;
+    const allowed = new Set(keyIds);
+    return data.filter((indicator) => allowed.has(indicator.id));
+  }, [data, keyIds, scope]);
 
   const filtered = useMemo(() => {
     const q = deferredQuery.trim();
-    if (q === "") return data;
-    return data
+    if (q === "") return scoped;
+    return scoped
       .map((indicator) => ({ indicator, score: scoreIndicator(q, indicator) }))
       .filter((entry) => entry.score > 0)
       .sort((a, b) => b.score - a.score)
       .map((entry) => entry.indicator);
-  }, [data, deferredQuery]);
+  }, [scoped, deferredQuery]);
 
-  const state: "error" | "loading" | "empty" | "no-matches" | "ready" = error !== null
+  const state: "error" | "loading" | "empty" | "empty-key" | "no-matches" | "ready" = error !== null
     ? "error"
     : isLoading
     ? "loading"
     : data.length === 0
     ? "empty"
+    : scoped.length === 0
+    ? "empty-key"
     : filtered.length === 0
     ? "no-matches"
     : "ready";
@@ -50,9 +61,10 @@ export function IndicatorsGrid({ data, isLoading, error }: IndicatorsGridProps) 
           {state === "ready" && (
             <span className="font-mono text-xs uppercase text-steel-gray">
               {filtered.length}
-              {query !== "" && filtered.length !== data.length ? ` / ${data.length}` : ""} INDICATORS
+              {query !== "" && filtered.length !== scoped.length ? ` / ${scoped.length}` : ""} INDICATORS
             </span>
           )}
+          <ScopeToggle value={scope} onChange={setScope} />
           <ViewToggle value={view} onChange={setView} />
         </div>
       </div>
@@ -105,6 +117,10 @@ export function IndicatorsGrid({ data, isLoading, error }: IndicatorsGridProps) 
         <EmptyState>INDICATORS NOT YET COMPUTED</EmptyState>
       )}
 
+      {state === "empty-key" && (
+        <EmptyState>NO KEY INDICATORS AVAILABLE</EmptyState>
+      )}
+
       {state === "no-matches" && (
         <EmptyState>NO MATCHES FOR &quot;{query}&quot;</EmptyState>
       )}
@@ -145,6 +161,28 @@ function EmptyState({ children }: { children: React.ReactNode }) {
   );
 }
 
+function ScopeToggle({ value, onChange }: { value: Scope; onChange: (v: Scope) => void }) {
+  return (
+    <div
+      role="group"
+      aria-label="Indicator scope"
+      className="inline-flex border border-electric-cyan bg-background"
+    >
+      <ToggleButton
+        active={value === "key"}
+        onClick={() => onChange("key")}
+        label="KEY"
+      />
+      <ToggleButton
+        active={value === "all"}
+        onClick={() => onChange("all")}
+        label="ALL"
+        bordered
+      />
+    </div>
+  );
+}
+
 function ViewToggle({ value, onChange }: { value: ViewMode; onChange: (v: ViewMode) => void }) {
   return (
     <div
@@ -152,13 +190,13 @@ function ViewToggle({ value, onChange }: { value: ViewMode; onChange: (v: ViewMo
       aria-label="View mode"
       className="inline-flex border border-electric-cyan bg-background"
     >
-      <ViewToggleButton
+      <ToggleButton
         active={value === "list"}
         onClick={() => onChange("list")}
         label="LIST"
         icon={<List className="h-3.5 w-3.5" aria-hidden />}
       />
-      <ViewToggleButton
+      <ToggleButton
         active={value === "cards"}
         onClick={() => onChange("cards")}
         label="CARDS"
@@ -169,12 +207,12 @@ function ViewToggle({ value, onChange }: { value: ViewMode; onChange: (v: ViewMo
   );
 }
 
-function ViewToggleButton(
+function ToggleButton(
   { active, onClick, label, icon, bordered = false }: {
     active: boolean;
     onClick: () => void;
     label: string;
-    icon: React.ReactNode;
+    icon?: React.ReactNode;
     bordered?: boolean;
   },
 ) {
@@ -194,7 +232,7 @@ function ViewToggleButton(
       )}
     >
       {icon}
-      <span className="hidden sm:inline">{label}</span>
+      {icon ? <span className="hidden sm:inline">{label}</span> : label}
     </button>
   );
 }


### PR DESCRIPTION
## Summary
- Reorder dashboard sections: subfund pie chart → indicators grid → KEY METRICS HISTORY charts
- Add a KEY/ALL scope toggle on `IndicatorsGrid`, defaulting to KEY, that filters the grid to a curated set of 19 indicator IDs
- Search and view toggle now operate within the active scope; empty states distinguish "no data" from "no key indicators in data"
- Deduplicate `ScopeToggleButton`/`ViewToggleButton` into a single `ToggleButton` primitive; tighten `aria-label` on the scope group

## Test plan
- [x] `bun test src/components/dashboard/indicators-grid.test.tsx` (24/24 pass, 4 new cases for scope toggle and empty-key state)
- [x] `bun lint`
- [x] `bunx tsc --noEmit`
- [ ] Manual: load `/`, confirm grid sits between pie and history charts, KEY shows 19 indicators in API order, ALL shows full set, search restricts within current scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)