### PR TITLE
feat(stat.mtlf.me): shared snapshot date navigation in header

### DIFF
--- a/apps/stat.mtlf.me/app/fund/page.tsx
+++ b/apps/stat.mtlf.me/app/fund/page.tsx
@@ -1,8 +1,9 @@
+import { BackToDashboard } from "@/components/layout/back-to-dashboard";
 import { Footer } from "@/components/layout/footer";
+import { SnapshotNav } from "@/components/layout/snapshot-nav";
 import { PortfolioDemo } from "@/components/portfolio/portfolio-demo";
 import { ModeToggle } from "@/components/ui/mode-toggle";
-import { ArrowLeft } from "lucide-react";
-import Link from "next/link";
+import { Suspense } from "react";
 
 export default function FundPage() {
   return (
@@ -18,25 +19,24 @@ export default function FundPage() {
                 FUND STRUCTURE // ACCOUNTS // TOKENS
               </p>
             </div>
-            <ModeToggle />
+            <div className="flex items-center gap-4 flex-wrap">
+              <SnapshotNav />
+              <ModeToggle />
+            </div>
           </div>
         </div>
       </div>
 
       <div className="border-b border-border bg-background">
         <div className="container mx-auto px-6 py-3">
-          <Link
-            href="/"
-            className="inline-flex items-center gap-2 font-mono text-xs uppercase tracking-widest text-electric-cyan hover:text-cyber-green transition-colors"
-          >
-            <ArrowLeft className="h-3 w-3" />
-            BACK TO DASHBOARD
-          </Link>
+          <BackToDashboard />
         </div>
       </div>
 
       <main className="flex-1 py-8">
-        <PortfolioDemo />
+        <Suspense>
+          <PortfolioDemo />
+        </Suspense>
       </main>
 
       <Footer />

--- a/apps/stat.mtlf.me/app/page.tsx
+++ b/apps/stat.mtlf.me/app/page.tsx
@@ -1,6 +1,8 @@
 import { DashboardPage } from "@/components/dashboard/dashboard-page";
 import { Footer } from "@/components/layout/footer";
+import { SnapshotNav } from "@/components/layout/snapshot-nav";
 import { ModeToggle } from "@/components/ui/mode-toggle";
+import { Suspense } from "react";
 
 export default function Home() {
   return (
@@ -16,13 +18,18 @@ export default function Home() {
                 MONTELIBERO FOUNDATION // PORTFOLIO STATISTICS
               </p>
             </div>
-            <ModeToggle />
+            <div className="flex items-center gap-4 flex-wrap">
+              <SnapshotNav />
+              <ModeToggle />
+            </div>
           </div>
         </div>
       </div>
 
       <main className="flex-1 py-8">
-        <DashboardPage />
+        <Suspense>
+          <DashboardPage />
+        </Suspense>
       </main>
 
       <Footer />

--- a/apps/stat.mtlf.me/src/components/dashboard/dashboard-page.tsx
+++ b/apps/stat.mtlf.me/src/components/dashboard/dashboard-page.tsx
@@ -4,7 +4,8 @@ import { useIndicatorHistory } from "@/hooks/use-indicator-history";
 import { useIndicators } from "@/hooks/use-indicators";
 import { useSubfundBalance } from "@/hooks/use-subfund-balance";
 import type { Range } from "@/lib/api/types";
-import { useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { useMemo, useState } from "react";
 import { IndicatorComparisonChart } from "./indicator-comparison-chart";
 import { IndicatorHistoryChart } from "./indicator-history-chart";
 import { IndicatorsGrid } from "./indicators-grid";
@@ -40,12 +41,26 @@ const KEY_IDS = [
 const TOTAL_INDICATOR_ID = 3;
 
 export function DashboardPage() {
-  const { data: subfundData, isLoading: subfundLoading, error: subfundError } = useSubfundBalance();
-  const { data: indicators, isLoading: indicatorsLoading, error: indicatorsError } = useIndicators();
+  const searchParams = useSearchParams();
+  const date = searchParams.get("date");
+  const { data: subfundData, isLoading: subfundLoading, error: subfundError } = useSubfundBalance(date);
+  const { data: indicators, isLoading: indicatorsLoading, error: indicatorsError } = useIndicators(date);
   const [range, setRange] = useState<Range>("90d");
   const { series, isLoading: historyLoading, error: historyError } = useIndicatorHistory(KEY_IDS, range);
 
-  const seriesById = new Map(series.map((s) => [s.id, s]));
+  const fundHref = date !== null ? `/fund?date=${encodeURIComponent(date)}` : "/fund";
+
+  const seriesById = useMemo(() => {
+    const map = new Map(series.map((s) => [s.id, s]));
+    if (date === null) return map;
+    return new Map(
+      [...map.entries()].map(([id, s]) => [
+        id,
+        { ...s, points: s.points.filter((p) => p.date <= date) },
+      ]),
+    );
+  }, [series, date]);
+
   const totalIndicator = indicators.find((i) => i.id === TOTAL_INDICATOR_ID);
 
   return (
@@ -63,6 +78,7 @@ export function DashboardPage() {
           <SubfundPieChart
             slices={subfundData.slices}
             date={subfundData.date}
+            fundHref={fundHref}
             {...(totalIndicator !== undefined
               ? { totalValue: totalIndicator.value, totalUnit: totalIndicator.unit }
               : {})}

--- a/apps/stat.mtlf.me/src/components/dashboard/dashboard-page.tsx
+++ b/apps/stat.mtlf.me/src/components/dashboard/dashboard-page.tsx
@@ -56,12 +56,23 @@ export function DashboardPage() {
     return new Map(
       [...map.entries()].map(([id, s]) => [
         id,
-        { ...s, points: s.points.filter((p) => p.date <= date) },
+        { ...s, points: s.points.filter((p) => (p.date.split("T")[0] ?? p.date) <= date) },
       ]),
     );
   }, [series, date]);
 
   const totalIndicator = indicators.find((i) => i.id === TOTAL_INDICATOR_ID);
+
+  const renderHistoryChart = (kpi: { id: number; name: string }) => (
+    <IndicatorHistoryChart
+      key={kpi.id}
+      id={kpi.id}
+      fallbackName={kpi.name}
+      series={seriesById.get(kpi.id)}
+      isLoading={historyLoading}
+      error={historyError}
+    />
+  );
 
   return (
     <div className="container mx-auto space-y-8 px-4 py-8">
@@ -100,16 +111,7 @@ export function DashboardPage() {
           <RangeSelector value={range} onChange={setRange} />
         </div>
         <div className="grid gap-4 grid-cols-1 lg:grid-cols-2">
-          {KEY_INDICATORS.slice(0, COMPARISON_INSERT_AFTER).map((kpi) => (
-            <IndicatorHistoryChart
-              key={kpi.id}
-              id={kpi.id}
-              fallbackName={kpi.name}
-              series={seriesById.get(kpi.id)}
-              isLoading={historyLoading}
-              error={historyError}
-            />
-          ))}
+          {KEY_INDICATORS.slice(0, COMPARISON_INSERT_AFTER).map(renderHistoryChart)}
           <div className="lg:col-span-2">
             <IndicatorComparisonChart
               marketId={COMPARISON.marketId}
@@ -122,16 +124,7 @@ export function DashboardPage() {
               error={historyError}
             />
           </div>
-          {KEY_INDICATORS.slice(COMPARISON_INSERT_AFTER).map((kpi) => (
-            <IndicatorHistoryChart
-              key={kpi.id}
-              id={kpi.id}
-              fallbackName={kpi.name}
-              series={seriesById.get(kpi.id)}
-              isLoading={historyLoading}
-              error={historyError}
-            />
-          ))}
+          {KEY_INDICATORS.slice(COMPARISON_INSERT_AFTER).map(renderHistoryChart)}
         </div>
       </section>
     </div>

--- a/apps/stat.mtlf.me/src/components/dashboard/subfund-pie-chart.tsx
+++ b/apps/stat.mtlf.me/src/components/dashboard/subfund-pie-chart.tsx
@@ -20,6 +20,7 @@ interface SubfundPieChartProps {
   date: string;
   totalValue?: string;
   totalUnit?: string;
+  fundHref?: string;
 }
 
 interface ChartDatum {
@@ -56,7 +57,7 @@ const parseFiniteOrNull = (raw: string | undefined): number | null => {
   return Number.isFinite(n) ? n : null;
 };
 
-export function SubfundPieChart({ slices, date, totalValue, totalUnit }: SubfundPieChartProps) {
+export function SubfundPieChart({ slices, date, totalValue, totalUnit, fundHref = "/fund" }: SubfundPieChartProps) {
   const sliceValues = slices.map((s) => toFiniteNumber(s.value));
   const total = sliceValues.reduce((sum, v) => sum + v, 0);
   const enriched: ChartDatum[] = slices.map((slice, i) => {
@@ -140,7 +141,7 @@ export function SubfundPieChart({ slices, date, totalValue, totalUnit }: Subfund
           </div>
         </div>
         <Link
-          href="/fund"
+          href={fundHref}
           className="inline-flex items-center gap-2 border border-electric-cyan bg-background px-4 py-2 font-mono text-xs uppercase tracking-wider text-electric-cyan hover:bg-electric-cyan hover:text-background transition-colors"
         >
           DETAILS

--- a/apps/stat.mtlf.me/src/components/layout/back-to-dashboard.tsx
+++ b/apps/stat.mtlf.me/src/components/layout/back-to-dashboard.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { ArrowLeft } from "lucide-react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { Suspense } from "react";
+
+function BackToDashboardInner() {
+  const searchParams = useSearchParams();
+  const date = searchParams.get("date");
+  const href = date != null ? `/?date=${encodeURIComponent(date)}` : "/";
+
+  return (
+    <Link
+      href={href}
+      className="inline-flex items-center gap-2 font-mono text-xs uppercase tracking-widest text-electric-cyan hover:text-cyber-green transition-colors"
+    >
+      <ArrowLeft className="h-3 w-3" />
+      BACK TO DASHBOARD
+    </Link>
+  );
+}
+
+export function BackToDashboard() {
+  return (
+    <Suspense fallback={
+      <Link
+        href="/"
+        className="inline-flex items-center gap-2 font-mono text-xs uppercase tracking-widest text-electric-cyan hover:text-cyber-green transition-colors"
+      >
+        <ArrowLeft className="h-3 w-3" />
+        BACK TO DASHBOARD
+      </Link>
+    }>
+      <BackToDashboardInner />
+    </Suspense>
+  );
+}

--- a/apps/stat.mtlf.me/src/components/layout/back-to-dashboard.tsx
+++ b/apps/stat.mtlf.me/src/components/layout/back-to-dashboard.tsx
@@ -5,11 +5,7 @@ import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { Suspense } from "react";
 
-function BackToDashboardInner() {
-  const searchParams = useSearchParams();
-  const date = searchParams.get("date");
-  const href = date != null ? `/?date=${encodeURIComponent(date)}` : "/";
-
+function DashboardLink({ href }: { href: string }) {
   return (
     <Link
       href={href}
@@ -21,17 +17,17 @@ function BackToDashboardInner() {
   );
 }
 
+function BackToDashboardInner() {
+  const searchParams = useSearchParams();
+  const date = searchParams.get("date");
+  const href = date !== null ? `/?date=${encodeURIComponent(date)}` : "/";
+
+  return <DashboardLink href={href} />;
+}
+
 export function BackToDashboard() {
   return (
-    <Suspense fallback={
-      <Link
-        href="/"
-        className="inline-flex items-center gap-2 font-mono text-xs uppercase tracking-widest text-electric-cyan hover:text-cyber-green transition-colors"
-      >
-        <ArrowLeft className="h-3 w-3" />
-        BACK TO DASHBOARD
-      </Link>
-    }>
+    <Suspense fallback={<DashboardLink href="/" />}>
       <BackToDashboardInner />
     </Suspense>
   );

--- a/apps/stat.mtlf.me/src/components/layout/snapshot-nav.tsx
+++ b/apps/stat.mtlf.me/src/components/layout/snapshot-nav.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { useSnapshots } from "@/hooks/use-snapshots";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense } from "react";
+
+const formatDate = (dateStr: string): string =>
+  new Date(dateStr).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  }).toUpperCase();
+
+function SnapshotNavInner() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const selectedDate = searchParams.get("date");
+  const { snapshots, isLoading } = useSnapshots();
+
+  const handleChange = (value: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (value === "latest") {
+      params.delete("date");
+    } else {
+      params.set("date", value);
+    }
+    const qs = params.toString();
+    router.push(qs.length > 0 ? `?${qs}` : "?", { scroll: false });
+  };
+
+  return (
+    <Select
+      value={selectedDate ?? "latest"}
+      onValueChange={handleChange}
+      disabled={isLoading}
+    >
+      <SelectTrigger className="h-12 w-[200px] rounded-none border-electric-cyan bg-background font-mono text-xs uppercase tracking-wider focus:ring-0 focus:ring-offset-0">
+        <SelectValue placeholder="LOADING..." />
+      </SelectTrigger>
+      <SelectContent className="max-h-[400px] rounded-none border-electric-cyan bg-background">
+        <SelectItem
+          value="latest"
+          className="rounded-none font-mono text-xs uppercase tracking-wider cursor-pointer focus:bg-electric-cyan/20"
+        >
+          LATEST
+        </SelectItem>
+        {snapshots.map((snapshot) => (
+          <SelectItem
+            key={snapshot.date}
+            value={snapshot.date}
+            className="rounded-none font-mono text-xs cursor-pointer focus:bg-steel-gray/20"
+          >
+            {formatDate(snapshot.date)}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+export function SnapshotNav() {
+  return (
+    <Suspense fallback={
+      <div className="h-12 w-[200px] border border-electric-cyan/30 bg-background font-mono text-xs uppercase tracking-wider flex items-center px-3 text-steel-gray/50">
+        LOADING...
+      </div>
+    }>
+      <SnapshotNavInner />
+    </Suspense>
+  );
+}

--- a/apps/stat.mtlf.me/src/components/portfolio/portfolio-demo.tsx
+++ b/apps/stat.mtlf.me/src/components/portfolio/portfolio-demo.tsx
@@ -3,15 +3,15 @@
 import { FundStructureLoading } from "@/components/ui/loading-skeleton";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useFundData } from "@/hooks/use-fund-data";
-import { useSnapshots } from "@/hooks/use-snapshots";
 import { EXPLORERS, loadExplorer, LORE_MTLPROG, saveExplorer } from "@/lib/blockchain-explorer";
+import { useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { FundStructureTable } from "./fund-structure-table";
 
 export function PortfolioDemo() {
-  const [selectedDate, setSelectedDate] = useState<string | null>(null);
+  const searchParams = useSearchParams();
+  const selectedDate = searchParams.get("date");
   const [explorer, setExplorer] = useState(LORE_MTLPROG);
-  const { snapshots, isLoading: snapshotsLoading, error: snapshotsError } = useSnapshots();
   const { data: fundData, isLoading, error } = useFundData(selectedDate);
 
   useEffect(() => {
@@ -27,12 +27,12 @@ export function PortfolioDemo() {
 
   return (
     <div className="container mx-auto px-4 py-16">
-      <div className="mb-8 grid grid-cols-[auto_1fr] sm:grid-cols-[auto_auto_auto_auto] items-center gap-x-4 gap-y-3 sm:justify-end">
+      <div className="mb-8 flex items-center gap-x-4 justify-end">
         <label className="font-mono text-sm uppercase tracking-wider text-steel-gray whitespace-nowrap">
           EXPLORER:
         </label>
         <Select value={explorer.id} onValueChange={handleExplorerChange}>
-          <SelectTrigger className="w-full sm:w-[200px] border-electric-cyan bg-background font-mono text-sm uppercase">
+          <SelectTrigger className="w-[200px] border-electric-cyan bg-background font-mono text-sm uppercase">
             <SelectValue />
           </SelectTrigger>
           <SelectContent className="border-electric-cyan bg-background">
@@ -47,48 +47,14 @@ export function PortfolioDemo() {
             ))}
           </SelectContent>
         </Select>
-
-        <label className="font-mono text-sm uppercase tracking-wider text-steel-gray whitespace-nowrap">
-          SNAPSHOT:
-        </label>
-        <Select
-          value={selectedDate ?? "latest"}
-          onValueChange={(value) => setSelectedDate(value === "latest" ? null : value)}
-          disabled={snapshotsLoading}
-        >
-          <SelectTrigger className="w-full sm:w-[260px] border-electric-cyan bg-background font-mono text-sm uppercase">
-            <SelectValue placeholder="LOADING..." />
-          </SelectTrigger>
-          <SelectContent className="max-h-[400px] border-electric-cyan bg-background">
-            <SelectItem
-              value="latest"
-              className="font-mono text-sm uppercase cursor-pointer hover:bg-electric-cyan/20"
-            >
-              LATEST SNAPSHOT
-            </SelectItem>
-            {snapshots.map((snapshot) => (
-              <SelectItem
-                key={snapshot.date}
-                value={snapshot.date}
-                className="font-mono text-sm cursor-pointer hover:bg-steel-gray/20"
-              >
-                {new Date(snapshot.date).toLocaleDateString("en-US", {
-                  year: "numeric",
-                  month: "long",
-                  day: "numeric",
-                })}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
       </div>
 
-      {(error ?? snapshotsError) != null && (
+      {error != null && (
         <div className="border border-red-500 bg-red-500/10 p-6">
           <h2 className="font-mono text-red-500 uppercase tracking-wider text-xl mb-2">
             LOAD ERROR
           </h2>
-          <p className="font-mono text-red-400">{error ?? snapshotsError}</p>
+          <p className="font-mono text-red-400">{error}</p>
         </div>
       )}
 

--- a/apps/stat.mtlf.me/src/hooks/use-indicators.ts
+++ b/apps/stat.mtlf.me/src/hooks/use-indicators.ts
@@ -1,4 +1,4 @@
-import { fetchIndicators } from "@/lib/api/indicators";
+import { fetchIndicators, fetchIndicatorsByDate } from "@/lib/api/indicators";
 import type { Indicator } from "@/lib/api/types";
 import { useApiResource } from "./use-api-resource";
 
@@ -8,11 +8,12 @@ interface UseIndicatorsState {
   error: string | null;
 }
 
-export function useIndicators(): UseIndicatorsState {
+export function useIndicators(date?: string | null): UseIndicatorsState {
+  const dateKey = date?.split("T")[0] ?? null;
   const { data, isLoading, error } = useApiResource(
     "useIndicators",
-    (options) => fetchIndicators(options),
-    [],
+    (options) => (dateKey !== null ? fetchIndicatorsByDate(dateKey, options) : fetchIndicators(options)),
+    [dateKey],
   );
   return { data: data ?? [], isLoading, error };
 }

--- a/apps/stat.mtlf.me/src/hooks/use-subfund-balance.ts
+++ b/apps/stat.mtlf.me/src/hooks/use-subfund-balance.ts
@@ -8,10 +8,11 @@ interface UseSubfundBalanceState {
   error: string | null;
 }
 
-export function useSubfundBalance(): UseSubfundBalanceState {
+export function useSubfundBalance(date?: string | null): UseSubfundBalanceState {
+  const dateKey = date?.split("T")[0] ?? null;
   return useApiResource<BalanceBySubfund>(
     "useSubfundBalance",
-    (options) => fetchBalanceBySubfund(options),
-    [],
+    (options) => fetchBalanceBySubfund(dateKey, options),
+    [dateKey],
   );
 }

--- a/apps/stat.mtlf.me/src/lib/api/charts.ts
+++ b/apps/stat.mtlf.me/src/lib/api/charts.ts
@@ -1,6 +1,7 @@
 import { apiGet, type ApiGetOptions } from "./client";
 import type { BalanceBySubfund } from "./types";
 
-export function fetchBalanceBySubfund(options?: ApiGetOptions): Promise<BalanceBySubfund> {
-  return apiGet<BalanceBySubfund>("/api/v1/charts/balance-by-subfund", options);
+export function fetchBalanceBySubfund(date?: string | null, options?: ApiGetOptions): Promise<BalanceBySubfund> {
+  const path = date != null ? `/api/v1/charts/balance-by-subfund?date=${encodeURIComponent(date)}` : "/api/v1/charts/balance-by-subfund";
+  return apiGet<BalanceBySubfund>(path, options);
 }

--- a/apps/stat.mtlf.me/src/lib/api/indicators.ts
+++ b/apps/stat.mtlf.me/src/lib/api/indicators.ts
@@ -18,17 +18,9 @@ export async function fetchIndicators(options?: ApiGetOptions): Promise<Indicato
   }
 }
 
-export async function fetchIndicatorsByDate(date: string, options?: ApiGetOptions): Promise<Indicator[]> {
+export function fetchIndicatorsByDate(date: string, options?: ApiGetOptions): Promise<Indicator[]> {
   const path = `/api/v1/indicators/${encodeURIComponent(date)}?${COMPARE_QUERY}`;
-  try {
-    return await apiGet<Indicator[]>(path, options);
-  } catch (error) {
-    if (error instanceof ApiNotFoundError) {
-      logWarn("api.indicators", `404 from ${error.path} for date ${date} — treating as empty list`);
-      return [];
-    }
-    throw error;
-  }
+  return apiGet<Indicator[]>(path, options);
 }
 
 export function fetchIndicatorHistory(

--- a/apps/stat.mtlf.me/src/lib/api/indicators.ts
+++ b/apps/stat.mtlf.me/src/lib/api/indicators.ts
@@ -3,14 +3,28 @@ import { logWarn } from "./log";
 import type { Indicator, IndicatorHistory, Range } from "./types";
 
 const COMPARE_PERIODS: readonly Range[] = ["30d", "90d", "365d"];
+const COMPARE_QUERY = `compare=${COMPARE_PERIODS.join(",")}`;
 
 export async function fetchIndicators(options?: ApiGetOptions): Promise<Indicator[]> {
-  const path = `/api/v1/indicators?compare=${COMPARE_PERIODS.join(",")}`;
+  const path = `/api/v1/indicators?${COMPARE_QUERY}`;
   try {
     return await apiGet<Indicator[]>(path, options);
   } catch (error) {
     if (error instanceof ApiNotFoundError) {
       logWarn("api.indicators", `404 from ${error.path} — treating as empty list`);
+      return [];
+    }
+    throw error;
+  }
+}
+
+export async function fetchIndicatorsByDate(date: string, options?: ApiGetOptions): Promise<Indicator[]> {
+  const path = `/api/v1/indicators/${encodeURIComponent(date)}?${COMPARE_QUERY}`;
+  try {
+    return await apiGet<Indicator[]>(path, options);
+  } catch (error) {
+    if (error instanceof ApiNotFoundError) {
+      logWarn("api.indicators", `404 from ${error.path} for date ${date} — treating as empty list`);
       return [];
     }
     throw error;


### PR DESCRIPTION
## Summary

- Adds `SnapshotNav` component — a Select dropdown styled with `rounded-none h-12 border-electric-cyan` to match the app's brutalist design and ModeToggle height; placed in the header of both `/` and `/fund`
- State lives in `?date=` URL param — selecting a date updates all data on the page; navigation between pages preserves the param via `BackToDashboard` and `fundHref`
- `fetchIndicatorsByDate(date)` — new API wrapper for `GET /api/v1/indicators/{date}?compare=...`; hooks `useIndicators` and `useSubfundBalance` accept optional `date` param
- History charts filter series points to `<= selectedDate` so they clip to the selected snapshot rather than always showing the latest window
- DETAILS button in `SubfundPieChart` now navigates to `/fund?date=...` when a date is active

## Test plan

- [ ] Visit `/`, select a historical date from the header dropdown — verify indicators, pie chart, and history charts all update
- [ ] Click DETAILS with a date selected — verify `/fund` opens with the same `?date=` param and shows the matching snapshot
- [ ] On `/fund`, click BACK TO DASHBOARD — verify `/` retains the selected date
- [ ] With LATEST selected, verify DETAILS navigates to plain `/fund` and all data shows the latest
- [ ] Check responsive layout: SnapshotNav + ModeToggle wrap cleanly on narrow screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)